### PR TITLE
Adding blog category pages and a few minor improvements

### DIFF
--- a/_includes/catmenu.html
+++ b/_includes/catmenu.html
@@ -1,0 +1,13 @@
+   <div class="blog-cats">
+
+     <h5><a href="{{site.baseurl}}/blog/index.html">All Posts</a></h5>
+
+     <h5>Posts by Category</h5>
+
+     <ul>
+     {% assign catlist = site.categories | sort %}
+     {% for cat in catlist %}
+         <li><a href="{{site.baseurl/blog/}}{{cat | first}}.html">{{cat | first}}</a> ({{cat[1] | size}})</li>
+     {% endfor %}
+     </ul>
+   </div>

--- a/_includes/post_link.html
+++ b/_includes/post_link.html
@@ -1,0 +1,9 @@
+      <li>
+        <h4>
+          <a class="post-link" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
+        </h4>
+        <span class="post-date">
+	  <p>{{ post.date | date: "%b %-d, %y" }}, Written by {{post.author}}</p>
+	</span>
+        <p>{{ post.excerpt }}</p>
+      </li>

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+
+  {% include head.html %}
+
+    <body>
+
+    {% include header.html %}
+    {% include catmenu.html %}
+
+
+    <div class="page-content">
+      <div class="wrap">
+	<div class="post">
+	    <div class="main">
+
+	    <header class="post-header">
+		<h1>{{ page.title }}</h1>
+	    </header>
+
+	    <article class="post-content">
+	    {{ content }}
+	    </article>
+	    </div>
+
+	</div>
+      </div>
+    </div>
+
+    {% include footer.html %}
+
+    </body>
+</html>

--- a/_layouts/catpage.html
+++ b/_layouts/catpage.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+
+  {% include head.html %}
+
+    <body>
+
+    {% include header.html %}
+    {% include catmenu.html %}
+
+    <div class="page-content">
+      <div class="wrap">
+	<div class="post">
+	    <div class="main">
+
+	    <header class="post-header">
+		<h1>Category: {{ page.category }}</h1>
+	    </header>
+
+	    <article class="post-content">
+	    <ul class="posts">
+		{% for post in site.categories[page.category] %}
+		    {% include post_link.html %}
+		{% endfor %}
+	    </ul>
+	    </article>
+	    </div>
+
+	</div>
+      </div>
+    </div>
+
+    {% include footer.html %}
+
+    </body>
+</html>

--- a/_posts/2015-01-16-making-an-app-in-python-using-kivy-1.md
+++ b/_posts/2015-01-16-making-an-app-in-python-using-kivy-1.md
@@ -1,7 +1,7 @@
 ---
 layout     : post
 title      : "Making an App in python using Kivy - Part 1"
-categories : blog kivy
+categories : blog kivy tutorial
 tags       : blog
 author     : Timothy
 comments   : true

--- a/_posts/2015-01-28-making-an-app-in-python-using-kivy-2.md
+++ b/_posts/2015-01-28-making-an-app-in-python-using-kivy-2.md
@@ -1,10 +1,10 @@
 ---
 layout     : post
 title      : "Making an App in python using Kivy - Part 2 - Widgets"
-categories : blog kivy
+categories : blog kivy tutorial
 tags       : blog
 author     : Timothy
-comments   : ture
+comments   : true
 ---
 
 In the [first part]({% post_url 2015-01-16-making-an-app-in-python-using-kivy-1 %}) I talked about how to create an app.

--- a/blog/atom.html
+++ b/blog/atom.html
@@ -1,0 +1,4 @@
+---
+layout: catpage
+category: atom
+---

--- a/blog/blog.html
+++ b/blog/blog.html
@@ -1,0 +1,4 @@
+---
+layout: catpage
+category: blog
+---

--- a/blog/emacs.html
+++ b/blog/emacs.html
@@ -1,0 +1,4 @@
+---
+layout: catpage
+category: emacs
+---

--- a/blog/functional.html
+++ b/blog/functional.html
@@ -1,0 +1,4 @@
+---
+layout: catpage
+category: functional
+---

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,17 +1,11 @@
 ---
-layout: page
+layout: blog
 title: Code Club Blog
 ---
 
+
 <ul class="posts">
 {% for post in site.posts %}
-  <li>
-    <a class="post-link" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
-    <span class="post-date">
-	<p>Written by {{post.author}}, {{ post.date | date: "%b %-d, %Y" }}</p>
-	<br/>
-    </span>
-    {{ post.excerpt }}
-  </li>
+    {% include post_link.html %}
 {% endfor %}
 </ul>

--- a/blog/kivy.html
+++ b/blog/kivy.html
@@ -1,0 +1,4 @@
+---
+layout: catpage
+category: kivy
+---

--- a/blog/pydiff.html
+++ b/blog/pydiff.html
@@ -1,0 +1,4 @@
+---
+layout: catpage
+category: pydiff
+---

--- a/blog/python.html
+++ b/blog/python.html
@@ -1,0 +1,4 @@
+---
+layout: catpage
+category: python
+---

--- a/blog/tutorial.html
+++ b/blog/tutorial.html
@@ -1,0 +1,4 @@
+---
+layout: catpage
+category: tutorial
+---

--- a/blog/vim.html
+++ b/blog/vim.html
@@ -1,0 +1,4 @@
+---
+layout: catpage
+category: vim
+---

--- a/blog/website.html
+++ b/blog/website.html
@@ -1,0 +1,4 @@
+---
+layout: catpage
+category: website
+---

--- a/css/main.css
+++ b/css/main.css
@@ -80,6 +80,18 @@ a:visited { color: #fbff00; }
   letter-spacing: -.5px;
 }
 
+.blog-cats {
+    font-size: 16px;
+    float: left;
+    margin-top: 75px;
+    padding: 5px;
+    background-color: #000000
+}
+
+.blog-cats h5 {
+    font-size: 26px;
+}
+
 /* Site footer */
 
 .site-footer {

--- a/index.html
+++ b/index.html
@@ -35,15 +35,7 @@ Do you think it sounds like a great idea, but are looking for an excuse to turn 
 
 <ul class="posts">
   {% for post in site.posts limit:7 %}
-      <li>
-        <h4>
-          <a class="post-link" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
-        </h4>
-        <span class="post-date">
-	  <p>Written by {{post.author}}, {{ post.date | date: "%b %-d, %Y" }}</p>
-	</span>
-        <p>{{ post.excerpt }}</p>
-      </li>
+      {% include post_link.html %}
   {% endfor %}
 </ul>
 </p>


### PR DESCRIPTION
This is a rather big set of changes so, hold on to your hats...

The blog page now has a category menu! This means the following:

    - The blog page now has its own layout in `_layouts` called `blog.html`
    - You can now filter blog posts according to the categor(y/ies) that
      they are placed in
    - By clicking on a category you are taken to a category page (these
      have to be added by hand - more on that later)
    - Since the category pages also need a category menu this has been
      abstracted out into `_includes/catmenu.html`. This is included in
      both `_layouts/blog.html` and `_layouts/catpage.html`
    - To create a category page simply create a HTML file with the new
      category's name in the `/blog` folder and add the following to the
      YAML front matter:
          + layout: catpage
          + category: <catname>
      where of course <catname> is the name of the category you are
      adding.
    - So that the category menu can appear on the side etc. we have
      added rules to `css/main.css`
    - Categories in the menu are sorted alphabetically and display the number
      of posts they contain

The following category pages have been added:

    - Atom
    - Emacs
    - Functional
    - Kivy
    - PyDiff
    - Python
    - Tutorial
    - Vim
    - Website

These are simply all the categories that already existed on the
website and some of them are more like tags and (in my opinion)
redundant. For example the Atom, Emacs and Vim category all simply point
to the first editor off post and nothing else. I will create an issue
referencing this PR if it gets merged where we can discuss this further.

With the introduction of the category menu there are now a number of places
where we need to list a number or posts (home, blog, categories etc.). So
to ensure we get a consistent look and feel, the for loop which iterates
through some list of posts and generates the HTML to display them has now been
but into `_includes/post_link.html`.

To include to lists of posts we now add the following to a page:

```
{% for post in <list of posts> %}
    {% include post_link.html %}
{% endfor %}
```

Where <list of posts> could be any list of posts e.g.

   - All of them `site.posts` (like on the blog page)
   - A subset of them `site.posts limit:7` (like on the home page)
   - All of them belonging to a category `site.categories[page.category]`
     (as on the new category pages)

Finally I've included a few screenshots so you can see the result:
![2015-11-20-093451_1280x800_scrot](https://cloud.githubusercontent.com/assets/2675694/11296436/09e92304-8f6a-11e5-98bd-7fe338048a1c.png)

![2015-11-20-093558_1280x800_scrot](https://cloud.githubusercontent.com/assets/2675694/11296458/23cbe1f8-8f6a-11e5-82a4-4d9eadc64830.png)
