### PR TITLE
Githublinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cardiff School of Mathematics Code Club
 
-[![Build status] (https://travis-ci.org/Huaraz2/CardiffMathematicsCodeClub.github.io.svg?branch=Githublinks)](https://travis-ci.org/Huaraz2/CardiffMathematicsCodeClub.github.io)
-<!-- [![Build Status](https://travis-ci.org/CardiffMathematicsCodeClub/CardiffMathematicsCodeClub.github.io.svg?branch=master)](https://travis-ci.org/CardiffMathematicsCodeClub/CardiffMathematicsCodeClub.github.io) -->
+<!-- [![Build status] (https://travis-ci.org/Huaraz2/CardiffMathematicsCodeClub.github.io.svg?branch=Githublinks)](https://travis-ci.org/Huaraz2/CardiffMathematicsCodeClub.github.io) -->
+[![Build Status](https://travis-ci.org/CardiffMathematicsCodeClub/CardiffMathematicsCodeClub.github.io.svg?branch=master)](https://travis-ci.org/CardiffMathematicsCodeClub/CardiffMathematicsCodeClub.github.io)
 
 A repository for the Cardiff School of Mathematics Code Club: an extra curricular club open to all.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Cardiff School of Mathematics Code Club
-[![Build Status](https://travis-ci.org/CardiffMathematicsCodeClub/CardiffMathematicsCodeClub.github.io.svg?branch=master)](https://travis-ci.org/CardiffMathematicsCodeClub/CardiffMathematicsCodeClub.github.io)
+
+[![Build status] (https://travis-ci.org/Huaraz2/CardiffMathematicsCodeClub.github.io.svg?branch=Githublinks)](https://travis-ci.org/Huaraz2/CardiffMathematicsCodeClub.github.io)
+<!-- [![Build Status](https://travis-ci.org/CardiffMathematicsCodeClub/CardiffMathematicsCodeClub.github.io.svg?branch=master)](https://travis-ci.org/CardiffMathematicsCodeClub/CardiffMathematicsCodeClub.github.io) -->
 
 A repository for the Cardiff School of Mathematics Code Club: an extra curricular club open to all.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# Cardiff School of Mathematics Code Club
-
-<!-- [![Build status] (https://travis-ci.org/Huaraz2/CardiffMathematicsCodeClub.github.io.svg?branch=Githublinks)](https://travis-ci.org/Huaraz2/CardiffMathematicsCodeClub.github.io) -->
+# Cardiff School of Mathematics Code Club  
 [![Build Status](https://travis-ci.org/CardiffMathematicsCodeClub/CardiffMathematicsCodeClub.github.io.svg?branch=master)](https://travis-ci.org/CardiffMathematicsCodeClub/CardiffMathematicsCodeClub.github.io)
 
 A repository for the Cardiff School of Mathematics Code Club: an extra curricular club open to all.

--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -16,7 +16,7 @@
 
 - name : Batduck
   title: Glitch in the Matirx
-  github-page: https://github.com/
+  github-page: https://github.com/BatDuck-Caboose
 
 - name : Geraint Palmer
   title: The Traitor

--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -24,7 +24,7 @@
 
 - name : Hannah Lorrimore
   title: Mother Hen
-  github-page: https://github.com/
+  github-page: https://github.com/hhlorrimore
 
 - name: James Hedge
   title: ...Pending...

--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -44,7 +44,7 @@
 
 - name: Sam Luen-English
   title: The Teacher
-  github-page: https://github.com/
+  github-page: https://github.com/sluenenglish
 
 - name: Seva Zozin
   title: The Padawan

--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -52,7 +52,7 @@
 
 - name : Tim Standen
   title: The Code Janitor
-  github-page: https://github.com/
+  github-page: https://github.com/timothyf1
 
 - name : Toby Devlin
   title: The drive-by bootstrapper

--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -8,7 +8,7 @@
 
 - name : Ambrose Law
   title: Django Jazz Hands
-  github-page: https://github.com/
+  github-page: https://github.com/Enyexlaw
 
 - name : Andy Wilson
   title: The Honourary Coder

--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -4,7 +4,7 @@
 
 - name : Alex Carney
   title: Leonardo
-  github-page: https://github.com/
+  github-page: https://github.com/alcarney
 
 - name : Ambrose Law
   title: Django Jazz Hands

--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -60,7 +60,7 @@
 
 - name : Vince Knight
   title: Colonel Sarge
-  github-page: https://github.com/
+  github-page: https://github.com/drvinceknight
 
 - name: Will Dudley
   title: ...Pending...

--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -20,7 +20,7 @@
 
 - name : Geraint Palmer
   title: The Traitor
-  github-page: https://github.com/
+  github-page: https://github.com/geraintpalmer
 
 - name : Hannah Lorrimore
   title: Mother Hen

--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -64,4 +64,4 @@
 
 - name: Will Dudley
   title: ...Pending...
-  github-page: https://github.com/
+  github-page: https://github.com/WillDudley

--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -32,7 +32,7 @@
 
 - name : Jason Young
   title: You Know Who
-  github-page: https://github.com/
+  github-page: https://github.com/JasYoung314
 
 - name: Laura Saul
   title: The Code Officer

--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -56,7 +56,7 @@
 
 - name : Toby Devlin
   title: The drive-by bootstrapper
-  github-page: https://github.com/
+  github-page: https://github.com/GitToby
 
 - name : Vince Knight
   title: Colonel Sarge

--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -48,7 +48,7 @@
 
 - name: Seva Zozin
   title: The Padawan
-  github-page: https://github.com/
+  github-page: https://github.com/chelyabinsk
 
 - name : Tim Standen
   title: The Code Janitor

--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -36,7 +36,7 @@
 
 - name: Laura Saul
   title: The Code Officer
-  github-page: https://github.com/
+  github-page: https://github.com/Aurora256
 
 - name: Preeti Sidhu
   title: ...Pending...

--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -12,7 +12,7 @@
 
 - name : Andy Wilson
   title: The Honourary Coder
-  github-page: https://github.com/
+  github-page: https://github.com/BatDuck-Caboose
 
 - name : Batduck
   title: Glitch in the Matirx

--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -28,7 +28,7 @@
 
 - name: James Hedge
   title: ...Pending...
-  github-page: https://github.com/
+  github-page: https://github.com/LordTandy
 
 - name : Jason Young
   title: You Know Who

--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -1,50 +1,67 @@
 - name : Adam Pohl
   title: The Webmaster
+  github-page: https://github.com/Huaraz2
 
 - name : Alex Carney
   title: Leonardo
+  github-page: https://github.com/
 
 - name : Ambrose Law
   title: Django Jazz Hands
+  github-page: https://github.com/
 
 - name : Andy Wilson
   title: The Honourary Coder
+  github-page: https://github.com/
 
 - name : Batduck
   title: Glitch in the Matirx
+  github-page: https://github.com/
 
 - name : Geraint Palmer
   title: The Traitor
+  github-page: https://github.com/
 
 - name : Hannah Lorrimore
   title: Mother Hen
+  github-page: https://github.com/
 
 - name: James Hedge
   title: ...Pending...
+  github-page: https://github.com/
 
 - name : Jason Young
   title: You Know Who
+  github-page: https://github.com/
 
 - name: Laura Saul
   title: The Code Officer
+  github-page: https://github.com/
 
 - name: Preeti Sidhu
   title: ...Pending...
+  github-page: https://github.com/
 
 - name: Sam Luen-English
   title: The Teacher
+  github-page: https://github.com/
 
 - name: Seva Zozin
   title: The Padawan
+  github-page: https://github.com/
 
 - name : Tim Standen
   title: The Code Janitor
+  github-page: https://github.com/
 
 - name : Toby Devlin
   title: The drive-by bootstrapper
+  github-page: https://github.com/
 
 - name : Vince Knight
   title: Colonel Sarge
+  github-page: https://github.com/
 
 - name: Will Dudley
   title: ...Pending...
+  github-page: https://github.com/

--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -40,7 +40,7 @@
 
 - name: Preeti Sidhu
   title: ...Pending...
-  github-page: https://github.com/
+  github-page: https://github.com/preetiks
 
 - name: Sam Luen-English
   title: The Teacher

--- a/getinvolved.html
+++ b/getinvolved.html
@@ -18,7 +18,7 @@ categories: getinvolved
 </center>
 <ul>
     {% for contributor in site.data.contributors%}
-<li class="contributor"><b>{{contributor.name}}</b> <i>({{contributor.title}})</i></li>
+<li class="contributor"><b>{{contributor.name}}</b> <i>(<a href="{{contributor.github-page}}">{{contributor.title}}</a>)</i></li>
     {% endfor %}
 </ul>
 <center>

--- a/index.html
+++ b/index.html
@@ -38,4 +38,4 @@ Do you think it sounds like a great idea, but are looking for an excuse to turn 
       {% include post_link.html %}
   {% endfor %}
 </ul>
-</p>
+</p> 


### PR DESCRIPTION
This makes the contributor title a link to the contributor's github page. As you can see in the gif below.

![githublinkspr](https://cloud.githubusercontent.com/assets/8998661/11407088/807cc40c-93a8-11e5-9305-7e9de63b6a44.gif)

:smiling_imp: 