### PR TITLE
Rewriting the reference and getting involved pages

### DIFF
--- a/_data/menu.yml
+++ b/_data/menu.yml
@@ -36,7 +36,5 @@
           url: /languages/java.html
         - text: Python
           url: /languages/python.html
-    - text: Projects
-      url: /projects/
 - text: Get involved
   url: '/getinvolved.html'

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -1,22 +1,27 @@
 - name: 'The Code Club website'
   github: https://github.com/CardiffMathematicsCodeClub/CardiffMathematicsCodeClub.github.io
   description: 'The very website you are currently looking at.'
+  active: true
 
 - name: 'A module planner'
   github: https://github.com/alcarney/Module-Planner
   description: 'A web based tool to graphically display course choice options.'
   link: http://module-planner.readthedocs.org/en/latest/
+  active: false
 
 - name: 'Axelrod'
   github: https://github.com/Axelrod-Python/Axelrod
   description: 'A repository used to reproduce Axelrods tournament.'
   link: http://axelrod.readthedocs.org/
+  active: true
 
 - name: 'The game has changed'
   github: https://github.com/CardiffMathematicsCodeClub/unknown-horizons
   description: 'A game challenge run by github (progress... ongoing...)'
   link: https://github.com/blog/1972-the-game-has-changed
+  active: false
 
 - name: 'ELBOW!!!'
   github: https://github.com/CardiffMathematicsCodeClub/elbow
   description: 'ELBOW ->(translate to french)-> COUDE ->(misspell)-> COUD ->(misspell again)-> CUOD -> Cardiff University Open Day'
+  active: true

--- a/getinvolved.html
+++ b/getinvolved.html
@@ -3,6 +3,54 @@ layout: page
 title: Get Involved
 categories: getinvolved
 ---
+
+<h3>Active Projects</h3>
+
+<p>
+  There are many concurrent projects being worked on at code club, below is a
+  list of all the active projects currently being developed. If wish want to see
+  a list of all projects then you can find them
+  <a href="{{site.baseurl}}/projects/">here</a> (if you see a project that interests
+  you there then by all means bring it back from the dead!)
+</p>
+
+<ul class="posts">
+{% for project in site.data.projects %}
+  {% if project.active %}
+    <li>
+    <p><b>{{project.name}}</b> - <a href={{project.github}}>Github repo</a></p>
+    <p><i>{{project.description}}</i></p>
+    {% if project.link %}<p><a href={{project.link}}>More info</a></p>{% endif %}
+    </li>
+  {% endif %}
+{% endfor %}
+</ul>
+
+<p>
+  Or if you have an idea for a project of your own and you'd like others to help/
+  work on it with you then send us a pull request and get it put up here!
+</p>
+
+<h3>Programming Challenges</h3>
+
+<p>
+  Don't feel ready yet to contribute to a full blown project? Don't worry below is a list of programming
+  challenges where you can develop your skills further and if you get stuck there will be
+  plenty of people at code club willing to help you get unstuck!
+</p>
+
+<ul>
+    <li><a href="https://projecteuler.net">Project Euler</a> - A site with over 450 problems many with a
+        mathematical focus to get your teeth into!</li>
+    <li><a href="http://www.reddit.com/r/dailyprogrammer/">Daily Programmer</a> - A subreddit with new problems
+        released on a Monday, Wednesday and Friday increasing in difficulty throughout the week. Challenges are based
+        on a wide variety of topics, often submitted by fellow users of the subreddit</li>
+    <li><a href="http://www.codingame.com/home/platinum-rift">Platinum Rift</a> - An online game.</li>
+    <li><a href="http://programmingpraxis.com/">Programming Praxis</a> - A blog with new exercises posted every few days
+        on a range of topics. Many of them are presented as a word problem.
+    <li><a href="http://vincent-knight.com">Vince's website</a> - A link to the Computing for Mathematics homepage.</li>
+</ul>
+
 <p>
     Here is a video that shows the various contributors so far (as of 4th of December 2014):
 </p>
@@ -13,9 +61,8 @@ categories: getinvolved
     </figure>
 </div>
 
-<center>
-    <b>Contributors to this website are:</b>
-</center>
+<h3>Contributors</h3>
+
 <ul>
     {% for contributor in site.data.contributors%}
 <li class="contributor"><b>{{contributor.name}}</b> <i>(<a href="{{contributor.github-page}}">{{contributor.title}}</a>)</i></li>

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@ improve your skills as a programmer while enjoying the pleasant company of other
 <p>
 Can't wait to come along? Well we meet in M/0.33, 16:00 - 18:00 on a Thursday, in the School of Mathematics building. <br/>
 Do you think it sounds like a great idea, but are looking for an excuse to turn up? Then be sure to check out our
-<a href="{{site.baseurl}}/reference.html">Inspiration</a> page.
+<a href="{{site.baseurl}}/getinvolved.html">getting involved</a> page.
 </p>
 
 <p><i><b>Disclaimer:</b> This website was made by programmers for programmers - please forgive any spelling mistakes!</i></p>
@@ -38,4 +38,4 @@ Do you think it sounds like a great idea, but are looking for an excuse to turn 
       {% include post_link.html %}
   {% endfor %}
 </ul>
-</p> 
+</p>

--- a/languages/brainfk.md
+++ b/languages/brainfk.md
@@ -2,5 +2,6 @@
 layout: language
 language: bf
 title: Brainf**k
-categories: inspiration forfun languages
+tags: forfun
+categories: inspiration languages
 ---

--- a/languages/brainfk.md
+++ b/languages/brainfk.md
@@ -2,5 +2,5 @@
 layout: language
 language: bf
 title: Brainf**k
-categories: inspiration languages
+categories: inspiration forfun languages
 ---

--- a/reference.html
+++ b/reference.html
@@ -32,7 +32,7 @@ categories: inspiration
         {% for page in site.pages %}
             {% if page.categories contains "languages" %}
 	        {% unless page.tags contains "forfun" %}
-                    <li><a href="{{ site.baseurl }}{{ pages.url }}">{{ page.title }}</a>
+                    <li><a href="{{ site.baseurl }}{{ page.url }}">{{ page.title }}</a>
 	        {% endunless %}
             {% endif %}
         {% endfor %}
@@ -56,7 +56,7 @@ categories: inspiration
         {% for page in site.pages %}
             {% if page.categories contains "languages" %}
 	        {% if page.tags contains "forfun" %}
-                    <li><a href="{{ site.baseurl }}{{ pages.url }}">{{ page.title }}</a>
+                    <li><a href="{{ site.baseurl }}{{ page.url }}">{{ page.title }}</a>
 	        {% endif %}
             {% endif %}
         {% endfor %}

--- a/reference.html
+++ b/reference.html
@@ -25,15 +25,39 @@ categories: inspiration
 </p>
 <p> Some of the more popular languages include <a href="{{site.baseurl}}/languages/java.html">Java</a>,
     <a href="{{site.baseurl}}/languages/python.html">Python</a> and <a href="{{site.baseurl}}/languages/C++.html">C++</a>.
-    However there are many more than that! Below are just a sample of them.
+    However there are many more than that! Below is just a sample of them.
 </p>
 <div class="two-cols">
     <ul>
-        {% for pages in site.pages %}
-            {% if pages.categories contains "languages" %}
-	        {% unless page.categories contains "forfun" %}
-                    <li><a href="{{ site.baseurl }}{{ pages.url }}">{{ pages.title }}</a>
+        {% for page in site.pages %}
+            {% if page.categories contains "languages" %}
+	        {% unless page.tags contains "forfun" %}
+                    <li><a href="{{ site.baseurl }}{{ pages.url }}">{{ page.title }}</a>
 	        {% endunless %}
+            {% endif %}
+        {% endfor %}
+    </ul>
+</div>
+
+<p>
+  Now what do programmers do when they are bored? Well they invent their own programming langauges of course!
+  These languages are not meant to be practical but rather offer some quirky or interesting way of trying
+  to make a computer do something - and often in the most painful way possible! These languages are often referrred
+  to as "Esoteric Languages".
+</p>
+
+<p>
+  Below is a list of some of these languages but I recommend you check out the
+  <a href="https://esolangs.org/wiki/Language_list">EsoLang Wiki</a> where you can find a long list of these languages!
+</p>
+
+<div class="two-cols">
+    <ul>
+        {% for page in site.pages %}
+            {% if page.categories contains "languages" %}
+	        {% if page.tags contains "forfun" %}
+                    <li><a href="{{ site.baseurl }}{{ pages.url }}">{{ page.title }}</a>
+	        {% endif %}
             {% endif %}
         {% endfor %}
     </ul>
@@ -50,24 +74,3 @@ categories: inspiration
         {% endfor %}
     </ul>
 </div>
-
-<h3>Programming Challenges</h3>
-<p>
-    Many places on the interest provide enthusiastic programmers with exercises and challenges
-    to flex their coding muscles. Below are links to a few of them:
-</p>
-<ul>
-    <li><a href="https://projecteuler.net">Project Euler</a> - A site with over 450 problems many with a
-        mathematical focus to get your teeth into!</li>
-    <li><a href="http://www.reddit.com/r/dailyprogrammer/">Daily Programmer</a> - A subreddit with new problems
-        released on a Monday, Wednesday and Friday increasing in difficulty throughout the week. Challenges are based
-        on a wide variety of topics, often submitted by fellow users of the subreddit</li>
-    <li><a href="http://www.codingame.com/home/platinum-rift">Platinum Rift</a> - An online game.</li>
-    <li><a href="http://programmingpraxis.com/">Programming Praxis</a> - A blog with new exercises posted every few days
-        on a range of topics. Many of them are presented as a word problem.
-    <li><a href="http://vincent-knight.com">Vince's website</a> - A link to the Computing for Mathematics homepage.</li>
-</ul>
-
-<h3>Stay Tuned</h3>
-
-<p>Watch this space, more coming soon...</p>

--- a/reference.html
+++ b/reference.html
@@ -1,15 +1,19 @@
 ---
 layout: page
-title: Inspiration
+title: Reference
 categories: inspiration
 ---
 
-<p> There is so much you can do during your time at Code Club anything
-    from learning a new programming languages such as <a href="{{site.baseurl}}/languages/java.html">Java</a>
-    or <a href="{{site.baseurl}}/languages/haskell.html">Haskell</a> to useful tools such
-    as <a href="https://git-scm.com">Git</a> for version control or <a href="{{site.baseurl}}/editors/vim.html">Vim</a>
-    for text editing to hacking away in <a href="http://pi.minecraft.net/?page_id=14">Minecraft</a>
-    for the Raspberry Pi! You are only limited by your imagination!
+<p>
+  Welcome to the reference section of the code club site. Here you will find information on a wide range of
+  programming languages, frameworks and tools to help you find something which interests you and how to get
+  started!
+</p>
+
+<p>
+  This section of the site is under constant development and if you find that we are missing something than we
+  strongly recommend that you <a href="{{site.baseurl}}/getinvolved.html">get involved</a> and send us a
+  pull request containing the missing information.
 </p>
 
 <h3>Programming Languages</h3>
@@ -26,8 +30,10 @@ categories: inspiration
 <div class="two-cols">
     <ul>
         {% for pages in site.pages %}
-            {% if pages.categories contains 'languages' %}
-                <li><a href="{{ site.baseurl }}{{ pages.url }}">{{ pages.title }}</a>
+            {% if pages.categories contains "languages" %}
+	        {% unless page.categories contains "forfun" %}
+                    <li><a href="{{ site.baseurl }}{{ pages.url }}">{{ pages.title }}</a>
+	        {% endunless %}
             {% endif %}
         {% endfor %}
     </ul>
@@ -65,4 +71,3 @@ categories: inspiration
 <h3>Stay Tuned</h3>
 
 <p>Watch this space, more coming soon...</p>
-


### PR DESCRIPTION
- Projects can now be toggled as 'active' or 'not active'
- To mark a project as active simply add `active: true` to the project's
  data in `_data/projects.yml`
- Active projects are listed on the getinvolved page with a link to the
  full list of projects
- Divided languages between "real" languages and "forfun" languages and
  have seperate sections for them on the main reference page
- To mark a language as "forfun" simply add the tag `forfun` in the YAML
  front matter of the language's page
- Programming challenges have been moved from the reference page to the
  getinvolved page
- Updated home page content to reflect the new structure of the site