### PR TITLE
Fixing the tests once and for all

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: ruby
 rvm:
     - 2.1
 
-script: ./script/cibuild
+script: rake
 
 env:
     global:

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,9 @@
+require 'html/proofer'
+
 task default: %w[test]
 
 task :test do
    sh "script/cibuild"
+   HTML::Proofer.new("./_site",
+    {:url_ignore => [%r{[Cc]ardiff[Mm]athematics[Cc]ode[Cc]lub\.github\.io}]}).run
 end

--- a/languages/clojure.md
+++ b/languages/clojure.md
@@ -1,0 +1,6 @@
+---
+layout: language
+language: clojure
+title: Clojure
+categories: inspiration languages
+---

--- a/script/cibuild
+++ b/script/cibuild
@@ -4,4 +4,4 @@
 set -e
 
 bundle exec jekyll build
-bundle exec htmlproof --url-ignore "http://cardiffmathematicscodeclub.github.io/*" ./_site
+#bundle exec htmlproof --url-ignore "http://cardiffmathematicscodeclub.github.io/*" ./_site


### PR DESCRIPTION
So it turns out the regexp we were using to ignore the code club links was incorrect, that has been fixed now also we now call `htmlproofer` from our `Rakefile`. There are many other options we can tweak and I might play with those in future...

However it might be a good idea to let the dust settle for a while...