### PR TITLE
This might fix the tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,5 +13,6 @@ end
 task :test do
    sh "script/cibuild"
    HTML::Proofer.new("./_site",
-    {:url_ignore => [%r{[Cc]ardiff[Mm]athematics[Cc]ode[Cc]lub\.github\.io}]}).run
+    {:url_ignore => [%r{[Cc]ardiff[Mm]athematics[Cc]ode[Cc]lub\.github\.io}],
+     :only_4xx => true}).run
 end


### PR DESCRIPTION
By only asking `html-proofer` to fail on 4xx errors then it should only report on errors we can do something about i.e. fixing broken links rather than internal server errors on other sites etc. (5xx erorrs) 