### PR TITLE
New way to add past sessions and contributors

### DIFF
--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -35,7 +35,7 @@ hannah:
 
 james:
   name: 'James Hedge'
-  title: ...Pending...
+  title: 
   github-page: https://github.com/LordTandy
 
 jason:
@@ -50,7 +50,7 @@ laura:
 
 preeti:
   name: 'Preeti Sidhu'
-  title: ...Pending...
+  title:
   github-page: https://github.com/preetiks
 
 saml:
@@ -85,5 +85,5 @@ vince:
 
 will:
   name: 'Will Dudley'
-  title: ...Pending...
+  title:
   github-page: https://github.com/WillDudley

--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -36,7 +36,7 @@ hannah:
 james:
   name: James Hedge
   title: ''
-  github-page: https://github.com/LordTandy
+  github-page: https://github.com/JamesHedge
 
 jason:
   name : Jason Young

--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -1,89 +1,89 @@
 adam:
-  name: 'Adam Pohl'
-  title: The Webmaster
+  name: Adam Pohl
+  title: 'The Webmaster'
   github-page: https://github.com/Huaraz2
 
 alex:
-  name : 'Alex Carney'
-  title: Leonardo
+  name : Alex Carney
+  title: 'Leonardo'
   github-page: https://github.com/alcarney
 
 ambrose:
-  name : 'Ambrose Law'
-  title: Django Jazz Hands
+  name : Ambrose Law
+  title: 'Django Jazz Hands'
   github-page: https://github.com/Enyexlaw
 
 andy:
-  name : 'Andy Wilson'
-  title: The Honourary Coder
+  name : Andy Wilson
+  title: 'The Honourary Coder'
   github-page: https://github.com/BatDuck-Caboose
 
 batduck:
-  name : 'Batduck'
-  title: Glitch in the Matirx
+  name : Batduck
+  title: 'Glitch in the Matirx'
   github-page: https://github.com/BatDuck-Caboose
 
 geraint:
-  name : 'Geraint Palmer'
-  title: The Traitor
+  name : Geraint Palmer
+  title: 'The Traitor'
   github-page: https://github.com/geraintpalmer
 
 hannah:
-  name : 'Hannah Lorrimore'
-  title: Mother Hen
+  name : Hannah Lorrimore
+  title: 'Mother Hen'
   github-page: https://github.com/hhlorrimore
 
 james:
-  name: 'James Hedge'
-  title: 
+  name: James Hedge
+  title: ''
   github-page: https://github.com/LordTandy
 
 jason:
-  name : 'Jason Young'
-  title: You Know Who
+  name : Jason Young
+  title: 'You Know Who'
   github-page: https://github.com/JasYoung314
 
 laura:
-  name: 'Laura Saul'
-  title: The Code Officer
+  name: Laura Saul
+  title: 'The Code Officer'
   github-page: https://github.com/Aurora256
 
 preeti:
-  name: 'Preeti Sidhu'
-  title:
+  name: Preeti Sidhu
+  title: ''
   github-page: https://github.com/preetiks
 
 saml:
-  name: 'Sam Luen-English'
-  title: The Teacher
+  name: Sam Luen-English
+  title: 'The Teacher'
   github-page: https://github.com/sluenenglish
 
 samr:
-  name: 'Sam Richardson'
-  title: Not Antoney
+  name: Sam Richardson
+  title: 'Not Antoney'
   github-page: https://github.com/SamLRichardson
 
 seva:
-  name: 'Seva Zozin'
-  title: The Padawan
+  name: Seva Zozin
+  title: 'The Padawan'
   github-page: https://github.com/chelyabinsk
 
 tim:
-  name : 'Tim Standen'
-  title: The Code Janitor
+  name : Tim Standen
+  title: 'The Code Janitor'
   github-page: https://github.com/timothyf1
 
 toby:
-  name : 'Toby Devlin'
-  title: The drive-by bootstrapper
+  name : Toby Devlin
+  title: 'The drive-by bootstrapper'
   github-page: https://github.com/GitToby
 
 vince:
-  name : 'Vince Knight'
-  title: Colonel Sarge
+  name : Vince Knight
+  title: 'Colonel Sarge'
   github-page: https://github.com/drvinceknight
 
 will:
-  name: 'Will Dudley'
-  title:
+  name: Will Dudley
+  title: ''
   github-page: https://github.com/WillDudley

--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -1,71 +1,89 @@
-- name : Adam Pohl
+adam:
+  name: 'Adam Pohl'
   title: The Webmaster
   github-page: https://github.com/Huaraz2
 
-- name : Alex Carney
+alex:
+  name : 'Alex Carney'
   title: Leonardo
   github-page: https://github.com/alcarney
 
-- name : Ambrose Law
+ambrose:
+  name : 'Ambrose Law'
   title: Django Jazz Hands
   github-page: https://github.com/Enyexlaw
 
-- name : Andy Wilson
+andy:
+  name : 'Andy Wilson'
   title: The Honourary Coder
   github-page: https://github.com/BatDuck-Caboose
 
-- name : Batduck
+batduck:
+  name : 'Batduck'
   title: Glitch in the Matirx
   github-page: https://github.com/BatDuck-Caboose
 
-- name : Geraint Palmer
+geraint:
+  name : 'Geraint Palmer'
   title: The Traitor
   github-page: https://github.com/geraintpalmer
 
-- name : Hannah Lorrimore
+hannah:
+  name : 'Hannah Lorrimore'
   title: Mother Hen
   github-page: https://github.com/hhlorrimore
 
-- name: James Hedge
+james:
+  name: 'James Hedge'
   title: ...Pending...
   github-page: https://github.com/LordTandy
 
-- name : Jason Young
+jason:
+  name : 'Jason Young'
   title: You Know Who
   github-page: https://github.com/JasYoung314
 
-- name: Laura Saul
+laura:
+  name: 'Laura Saul'
   title: The Code Officer
   github-page: https://github.com/Aurora256
 
-- name: Preeti Sidhu
+preeti:
+  name: 'Preeti Sidhu'
   title: ...Pending...
   github-page: https://github.com/preetiks
 
-- name: Sam Luen-English
+saml:
+  name: 'Sam Luen-English'
   title: The Teacher
   github-page: https://github.com/sluenenglish
 
-- name: Sam Richardson
+samr:
+  name: 'Sam Richardson'
   title: Not Antoney
   github-page: https://github.com/SamLRichardson
 
-- name: Seva Zozin
+seva:
+  name: 'Seva Zozin'
   title: The Padawan
   github-page: https://github.com/chelyabinsk
 
-- name : Tim Standen
+tim:
+  name : 'Tim Standen'
   title: The Code Janitor
   github-page: https://github.com/timothyf1
 
-- name : Toby Devlin
+toby:
+  name : 'Toby Devlin'
   title: The drive-by bootstrapper
   github-page: https://github.com/GitToby
 
-- name : Vince Knight
+vince:
+  name : 'Vince Knight'
   title: Colonel Sarge
   github-page: https://github.com/drvinceknight
 
-- name: Will Dudley
+will:
+  name: 'Will Dudley'
   title: ...Pending...
   github-page: https://github.com/WillDudley

--- a/_data/past_sessions.yml
+++ b/_data/past_sessions.yml
@@ -4,7 +4,7 @@
     - week   : 1
       name   : Wales v Fiji
       quote  : "Oh I didn't realise Django was used!"
-      author : The Padawan
+      author : seva
 
     - week   : 2
       name   : Editor Off
@@ -14,42 +14,47 @@
     - week   : 3
       name   : The Pregnancy Test
       quote  : "YAY Laura is pregnant with Ambrose's baby!!!"
-      author : Hannah 2<sup>nd</sup> year
+      author : hannah
 
     - week   : 4
-      name   : The Best One (Leonardo was absent)
+      name   : The Best One (alex was absent)
       quote  : "The code of conduct is up... and the website is broken"
-      author : Colonel Sarge
+      author : vince
 
     - week   : 5
       name   : The one where Django Jazz Hands DoS'd himself
       quote  : "How can you use 8gb's of Notepad...I don't understand"
-      author : Leonardo
+      author : alex
 
     - week   : 6
       name   : Big Vince is watching
       quote  : "I don't want to accidently walk into China with Tor on my laptop"
-      author : The Traitor
+      author : geraint
 
     - week   : 7
       name   : The text from Anna
       quote  : "I've known about that bug for the past 6 months"
-      author : The Code Janitor
+      author : tim
 
     - week   : 8
       name   : The one with the cake
       quote  : "I've got the whole website on one page?!?"
-      author : Leonardo
+      author : alex
 
     - week   : 9
       name   : The one with the tests
       quote  : "Hey Vince will be happy, we now have tests that break. I however am not!!"
-      author : The Webmaster
+      author : adam
 
     - week   : 10
       name   : fun is TabError
       quote  : "True, False = False, True"
-      author : Colonel Sarge
+      author : vince
+
+    - week   : 11
+      name   : The one with the werewolf
+      quote  : "Cthulhu wake up"
+      author : hannah
 
 - year: "2014-2015"
   term1: "Autumn"
@@ -57,42 +62,42 @@
     - week   : 1
       name   : Real Coders
       quote  : Only real coders code in Arch
-      author : You Know Who
+      author : jason
 
     - week   : 2
       name   : On the Fly
       quote  : Love the fact that I'm learning Vim on the fly!
-      author : The Webmaster
+      author : adam
 
     - week   : 3
       name   : The one where Vince ran away
       quote  : It's amazing how quiet it is without Jason
-      author : The Code Janitor
+      author : tim
 
     - week   : 4
       name   : What Django is for
       quote  : I know that Pinterest uses it but I can't see the connection
-      author : Leonardo
+      author : alex
 
     - week   : 5
       name   : Oh MongoDB
       quote  : I'm 100% onboard but why are we using Mongodb again?
-      author : Colonel Sarge
+      author : vince
 
     - week   : 6
       name   : Well 4 out of 5 work
       quote  : For once it's Vince's fault
-      author : You Know Who
+      author : jason
 
     - week   : 7
       name   : Jekyll and Hyde
       quote  : What if we use Jekyll for the base view and Hyde for the dynamic stuff
-      author : Leonardo
+      author : alex
 
     - week   : 8
       name   : Atom
       quote  : When your editor is finally done, it will be sooo good
-      author : Colonel Sarge
+      author : vince
 
     - week   : 9
       name   : Why we need Python 3...
@@ -102,56 +107,56 @@
     - week   : 10
       name   : Gource
       quote  : Guys come and look how cool this is!!!
-      author : Colonel Sarge
+      author : vince
 
     - week   : 11
       name   : Risk
       quote  : 6! You die.
-      author : Ellie 1st Year (Master dice roller)
+      author : Ellie 1<sup>st</sup> Year (Master dice roller)
 
   term2: "Spring"
   sessions2:
     - week   : 1
       name   : Three beeps
       quote  : Doesn't matter Tim will fix it.
-      author : Everyone (except Jason)
+      author : Everyone (except jason)
 
     - week   : 2
       name   : The session that was not a session
       quote  : Don't worry Vince will fix it.
-      author : The Code Janitor
+      author : tim
 
     - week   : 3
       name   : The one where the Padawan rocked the comand line
       quote  : Just a little joke to break the ice.
-      author : Not Anthony (Sam) 1<sup>st</sup> Year
+      author : samr
 
     - week   : 4
       name   : Axelrod
       quote  : Umm Alex... how easy would it be to install Arch on my home computer?
-      author : You Know Who
+      author : jason
 
     - week   : 5
       name   : Text Editor support group
       quote  : My name is Adam, and I am addicted to editing Atom.
-      author : The Webmaster
+      author : adam
 
     - week   : 6
       name   : Introducing Module Planner OS
       quote  : I will write it in Assembly for the Rasberry Pi
-      author : Leonardo
+      author : alex
 
     - week   : 7
       name   : The time that Jason licked his desk
       quote  : Is that a 1 or an l
-      author : The Code Janitor
+      author : tim
 
     - week   : 8
       name   : Fife off!!!
       quote  : Tim does not know everything sadly, why not try this new thing called the internet.
-      author : The Webmaster
+      author : adam
 
     - week   : 9
       name   : The one where Blender came in-to play
       quote  : WHY IS THIS NOT WORKING?!?
-      author : The Webmaster
+      author : adam

--- a/getinvolved.html
+++ b/getinvolved.html
@@ -8,7 +8,7 @@ categories: getinvolved
 
 <p>
   There are many concurrent projects being worked on at code club, below is a
-  list of all the active projects currently being developed. If wish want to see
+  list of all the active projects currently being developed. If you wish want to see
   a list of all projects then you can find them
   <a href="/projects/">here</a> (if you see a project that interests
   you there then by all means bring it back from the dead!)
@@ -31,21 +31,25 @@ categories: getinvolved
 <h3>Programming Challenges</h3>
 
 <p>
-  Don't feel ready yet to contribute to a full blown project? Don't worry below is a list of programming
-  challenges where you can develop your skills further and if you get stuck there will be
-  plenty of people at code club willing to help you get unstuck!
+  Don't feel ready yet to contribute to a full blown project? Don't worry below is a list of
+  programming challenges where you can develop your skills further and if you get stuck there
+  will be plenty of people at code club willing to help you get unstuck!
 </p>
 
 <ul>
-    <li><a href="https://projecteuler.net">Project Euler</a> - A site with over 450 problems many with a
-        mathematical focus to get your teeth into!</li>
-    <li><a href="http://www.reddit.com/r/dailyprogrammer/">Daily Programmer</a> - A subreddit with new problems
-        released on a Monday, Wednesday and Friday increasing in difficulty throughout the week. Challenges are based
-        on a wide variety of topics, often submitted by fellow users of the subreddit</li>
-    <li><a href="http://www.codingame.com/home/platinum-rift">Platinum Rift</a> - An online game.</li>
-    <li><a href="http://programmingpraxis.com/">Programming Praxis</a> - A blog with new exercises posted every few days
+    <li><a href="https://projecteuler.net">Project Euler</a> - A site with over 450 problems
+      many with a mathematical focus to get your teeth into!</li>
+    <li><a href="http://www.reddit.com/r/dailyprogrammer/">Daily Programmer</a> - A subreddit
+      with new problems released on a Monday, Wednesday and Friday increasing in difficulty
+      throughout the week. Challenges are based on a wide variety of topics, often submitted by
+      fellow users of the subreddit.</li>
+    <li><a href="http://www.codingame.com/home/platinum-rift">Platinum Rift</a> - An online
+      game.</li>
+    <li><a href="http://programmingpraxis.com/">Programming Praxis</a> - A blog with new
+      exercises posted every few days
         on a range of topics. Many of them are presented as a word problem.
-    <li><a href="http://vincent-knight.com">Vince's website</a> - A link to the Computing for Mathematics homepage.</li>
+    <li><a href="http://vincent-knight.com">Vince's website</a> - A link to the Computing for
+      Mathematics homepage.</li>
 </ul>
 
 <p>
@@ -61,10 +65,13 @@ categories: getinvolved
 <h3>Contributors</h3>
 
 <ul>
-    {% for contributor in site.data.contributors%}
-<li class="contributor"><b>{{contributor.name}}</b> <i>(<a href="{{contributor.github-page}}">{{contributor.title}}</a>)</i></li>
-    {% endfor %}
+  {% for contributor in site.data.contributors %}
+  {% assign person = contributor[1] %}
+    <li><b>{{person.name}}</b> <i>
+      (<a href="{{person.github-page}}">{{person.title}}</a>)</i></li>
+  {% endfor %}
 </ul>
 <center>
-    <i>Disclamer: This is NOT done in any particular order. It's definitly NOT in ALPHABETICAL order.</i>
+    <i>Disclamer: This is NOT done in any particular order.
+      It's definitly NOT in ALPHABETICAL order.</i>
 </center>

--- a/getinvolved.html
+++ b/getinvolved.html
@@ -68,7 +68,12 @@ categories: getinvolved
   {% for contributor in site.data.contributors %}
   {% assign person = contributor[1] %}
     <li><b>{{person.name}}</b> <i>
-      (<a href="{{person.github-page}}">{{person.title}}</a>)</i></li>
+      (<a href="{{person.github-page}}">
+        {% if person.title == nil %}
+          ...Pending...</a>)</i></li>
+        {% else %}
+          {{person.title}}</a>)</i></li>
+        {% endif %}
   {% endfor %}
 </ul>
 <center>

--- a/sessions.html
+++ b/sessions.html
@@ -16,9 +16,9 @@ categories: sessions
                       <li><b>Week {{session.week}} : </b> <i>"{{session.name}}"</i><br/>
                         <b>Quote of the session : </b> <i>"{{session.quote}}"</i><br/>
                         {% assign person = site.data.contributors[session.author] %}
-                        {% if person.title == nil %}
+                        {% if person.title == '' %}
                           {{person.name}}
-                        {% elsif person.title != nil %}
+                        {% elsif person.title %}
                           {{person.title}}</li>
                         {% else %}
                           {{session.author}}</li>

--- a/sessions.html
+++ b/sessions.html
@@ -16,7 +16,11 @@ categories: sessions
                       <li><b>Week {{session.week}} : </b> <i>"{{session.name}}"</i><br/>
                         <b>Quote of the session : </b> <i>"{{session.quote}}"</i><br/>
                         {% assign person = site.data.contributors[session.author] %}
+                        {% if person.title %}
                           {{person.title}}</li>
+                        {% else %}
+                          {{session.author}}</li>
+                        {% endif %}
                     {% endfor %}
                   </ul>
               </li>
@@ -28,7 +32,11 @@ categories: sessions
                     <li><b>Week {{session.week}} : </b> <i>"{{session.name}}"</i><br/>
                         <b>Quote of the session : </b> <i>"{{session.quote}}"</i><br/>
                         {% assign person = site.data.contributors[session.author] %}
+                        {% if person.title %}
                           {{person.title}}</li>
+                        {% else %}
+                          {{session.author}}</li>
+                        {% endif %}
                     {% endfor %}
                   </ul>
               </li>

--- a/sessions.html
+++ b/sessions.html
@@ -13,8 +13,10 @@ categories: sessions
               <li><em>{{year.term1}}</em>
                   <ul>
                     {% for session in year.sessions1 %}
-                    <li><b>Week {{session.week}} : </b> <i>"{{session.name}}"</i><br/>
-                        <b>Quote of the session : </b> <i>"{{session.quote}}"</i> {{session.author}}</li>
+                      <li><b>Week {{session.week}} : </b> <i>"{{session.name}}"</i><br/>
+                        <b>Quote of the session : </b> <i>"{{session.quote}}"</i><br/>
+                        {% assign person = site.data.contributors[session.author] %}
+                          {{person.title}}</li>
                     {% endfor %}
                   </ul>
               </li>
@@ -24,7 +26,9 @@ categories: sessions
                   <ul>
                     {% for session in year.sessions2 %}
                     <li><b>Week {{session.week}} : </b> <i>"{{session.name}}"</i><br/>
-                        <b>Quote of the session : </b> <i>"{{session.quote}}"</i> {{session.author}}</li>
+                        <b>Quote of the session : </b> <i>"{{session.quote}}"</i><br/>
+                        {% assign person = site.data.contributors[session.author] %}
+                          {{person.title}}</li>
                     {% endfor %}
                   </ul>
               </li>

--- a/sessions.html
+++ b/sessions.html
@@ -16,7 +16,9 @@ categories: sessions
                       <li><b>Week {{session.week}} : </b> <i>"{{session.name}}"</i><br/>
                         <b>Quote of the session : </b> <i>"{{session.quote}}"</i><br/>
                         {% assign person = site.data.contributors[session.author] %}
-                        {% if person.title %}
+                        {% if person.title == nil %}
+                          {{person.name}}
+                        {% elsif person.title != nil %}
                           {{person.title}}</li>
                         {% else %}
                           {{session.author}}</li>


### PR DESCRIPTION
So for a while now I have wanted to change the way we add the session quote auther. Basicaly I wanted to come up witha way to make the session author atumatically a person's title if they were a site contributor, ie I type `alex` as the author and on the website it would show up as `Leonardo`.  Now this could have been done with a for loop and an if statement but it made sessions.html look very messy and I want all of the code to be presentable enough so that people can look at it and instantly understand what is going on.

Alex suggested that I change the contributors.yml file to the same style as the projects.yml file and use the assign function.  So now when we go to write the session detailes we just put the auother down as by the person first name, ALL IN LOWERCASE, if they are a contributor to the website and then the code I have written will make it so that the output on the website will be their title.

In terms of how we now input a new contributor, instead of this:
```
-  name: Adam Pohl
   title: The Webmaster
   github-page: https://github.com/Huaraz2
```
we now write this:
```
adam:
  name: Adam Pohl
  title: 'The Webmaster'
  github-page: https://github.com/Huaraz2
```
The index for each contributor, `adam` in the above example, is what we put in the session author so that it comes up with their title on the website.  As Sam Richardson and Sam Leun-English have the same first name, I have written the index for their contributor info as `samr` and `saml` respectivley.

The last few commits look at atuomatically giving a contributor the title `...Pending...` if one has not been chosen for them and also making it so that if they a session quote author and don't have a title then their name is outputted instead.  

Below is an example of what we write if a contributor has no title:
```
james:
  name: James Hedge
  title: ''
  github-page: https://github.com/JamesHedge
```