### PR TITLE
Rake improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: ruby
 rvm:
     - 2.1
 
-script: rake
+script: rake test
 
 env:
     global:

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,9 @@
 source "https://rubygems.org"
 
 gem "rake"
+gem "fileutils"
+gem "github-pages"
 gem "jekyll"
 gem "jekyll-gist"
 gem "pygments.rb"
 gem "html-proofer"
-

--- a/Rakefile
+++ b/Rakefile
@@ -1,15 +1,77 @@
+require 'fileutils'
 require 'html/proofer'
+require 'yaml'
 
-task default: %w[test]
+task default: %w[help]
+task :help do
+  exec("rake -T")
+end
 
+desc 'Start working on a new post in _drafts'
+task :newpost, [:name] do |t, args|
+  front_matter = %q(
+---
+layout: post
+title: YOUR TITLE HERE
+categories: CATEGORY
+tags: TAGS
+author: YOUR NAME
+---
+
+Your awesome blog post goes here.
+See the "How to write a blog post" tutorial for more information on
+what can go here
+
+)
+
+  # If _drafts doesn't exist, make it
+  FileUtils.mkdir("_drafts") unless File.exists?("_drafts")
+
+  # Make sure the file doesn't already exist
+  if File.exists?("_drafts/#{args.name}.md")
+    raise "_drafts/#{args.name} already exists"
+  end
+
+  File.write("_drafts/#{args.name}.md", front_matter)
+
+end
+
+desc 'Publish a post in drafts'
+task :publishpost, [:name] do |t, args|
+
+  # Check it exists
+  if not File.exists?("_drafts/#{args.name}.md")
+    raise "_drafts/#{args.name}.md doesn't exist"
+  end
+
+  # Load the draft file
+
+  # First we need to get the YAML front matter for the post
+  # and enable comments.
+  #frontm = YAML.parse_file("_drafts/#{args.name}.md")
+  #frontm["comments"] = true
+
+  # Next we need to get the current date
+  time = Time.new
+  date = time.strftime("%Y-%m-%d")
+
+  FileUtils.mv("_drafts/#{args.name}.md", "_posts/#{date}-#{args.name}.md")
+
+  puts "Published post #{args.name}"
+
+end
+
+desc 'Run the jekyll server'
 task :preview do
     sh "jekyll serve"
 end
 
+desc 'Run the jekyll server, including all the drafts in _drafts'
 task :develop do
     sh "jekyll server --drafts"
 end
 
+desc 'Build the site and run the tests'
 task :test do
    sh "script/cibuild"
    HTML::Proofer.new("./_site",

--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,13 @@ task :help do
   exec("rake -T")
 end
 
+desc 'List all the drafts currently on the site'
+task :drafts do
+  Dir.glob("_drafts/*.md") do |file|
+    puts File.basename(file, ".md")
+  end
+end
+
 desc 'Start working on a new post in _drafts'
 task :newpost, [:name] do |t, args|
   front_matter = %q(
@@ -33,7 +40,7 @@ what can go here
   end
 
   File.write("_drafts/#{args.name}.md", front_matter)
-
+  puts "Draft post: _drafts/#{args.name}.md created"
 end
 
 desc 'Publish a post in drafts'
@@ -57,7 +64,7 @@ task :publishpost, [:name] do |t, args|
 
   FileUtils.mv("_drafts/#{args.name}.md", "_posts/#{date}-#{args.name}.md")
 
-  puts "Published post #{args.name}"
+  puts "Published post _drafts/#{args.name}.md as _posts/#{date}/#{args.name}.md"
 
 end
 


### PR DESCRIPTION
- __IMPORTANT:__ the default behavoir of `rake` is now to list all
  available tasks __NOT__ run the tests
- Tests now have to be explicitly run with `rake test`. `.travis.yml`
  has been updated to reflect this
- We have three new commands:
  + newpost
  + publishpost
  + drafts

newpost:

- New draft posts can be made using the following command

  ```
    $ rake newpost\[name-of-post\]
  ```

  or equivalently

  ```
    $ rake "newpost[name-of-post]"
  ```

  _Note:_ `name-of-post` should contain lowercase letters and no spaces

- This command will create a new markdown file `_drafts/name-of-post.md`
  as long as is doesn't already exist
- The file will contain boilerplate yaml frontmatter:

  ```
  ---
  layout: post
  title: YOUR TITLE HERE
  categories: CATEGORY
  tags: TAGS
  author: YOUR NAME
  ---

  Your awesome blog post goes here.
  See the "How to write a blog post" tutorial for more information on
  what can go here
  ```

publishpost:

- This takes a completed post from the drafts folder and publishes it
  with todays date
- Pushlishing an existing draft can be done as follows:

  ```
    $ rake publishpost\[name-of-post\]
  ```

  or equivalently

  ```
    $ rake "publishpost[name-of-post]"
  ```

  where `name-of-post` should match a file `name-of-post`.md file in the
  `_drafts` folder.
- Running this command will take a file `_drafts/name-of-post.md` and
  move it to `_posts/yyyy-mm-dd-name-of-post.md` where it will now be
  published next time the site is built.

drafts:

- This command lists all the drafts currently in `_drafts`, for example
  if the following files were in drafts:

  ```
  $ ls _drafts

  post.md
  another-post.md
  yet-another-good-post.md
  ```
  Then running `rake drafts` will give

  ```
  post
  another-post
  yet-another-good-post
  ```