### PR TITLE
Added blog pagination

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,6 @@ source "https://rubygems.org"
 gem "rake"
 gem "jekyll"
 gem "jekyll-gist"
+gem "jekyll-paginate"
 gem "pygments.rb"
 gem "html-proofer"
-

--- a/_config.yml
+++ b/_config.yml
@@ -5,9 +5,13 @@ url: "http://CardiffMathematicsCodeClub.github.io"
 markdown: kramdown
 highlighter: pygments
 
+paginate: 10
+paginate_path: "/blog/page:num"
+
 encoding: utf-8
 description: Cardiff University School of Mathematics Code Club website
 keywords: cardiff,university,uni,maths,math,mathematics,code,club,website,python,java,pascal,vb,elbow,atom,vim,sublime
 
 gems:
     - jekyll-gist
+    - jekyll-paginate

--- a/_includes/pagination_nav.html
+++ b/_includes/pagination_nav.html
@@ -1,0 +1,23 @@
+<div class="pagination">
+  <div class="buttons">
+    <div class="prev">
+        {% if paginator.previous_page %}
+	<a href="{{paginator.previous_page_path}}">
+	  <h4>Previous</h4>
+	</a>
+	{% else %}
+	<h4>Previous</h4>
+	{% endif %}
+    </div>
+
+    <div class="next">
+        {% if paginator.next_page %}
+	<a href="{{paginator.next_page_path}}">
+	  <h4>Next</h4>
+	</a>
+	{% else %}
+	  <h4>Next</h4>
+	{% endif %}
+    </div>
+  </div>
+</div>

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -24,6 +24,9 @@
 	    </div>
 
 	</div>
+
+	{% include pagination_nav.html %}
+
       </div>
     </div>
 

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -57,3 +57,24 @@ a {
 @include if-device($mobile) {
   .wrap { padding: 0 12px; }
 }
+
+.two-cols {
+  //@inlcude column-count(2);
+  -webkit-column-count: 2;
+     -moz-column-count: 2;
+          column-count: 2;
+}
+
+.pagination {
+
+  margin-top: 30px;
+
+  -webkit-column-count: 2;
+     -moz-column-count: 2;
+          column-count: 2;
+
+    .prev,
+    .next {
+      text-align: center;
+     }
+}

--- a/_sass/_elements/_base.scss
+++ b/_sass/_elements/_base.scss
@@ -10,6 +10,13 @@
   padding: 10px
 }
 
+.pagination {
+  .prev,
+  .next {
+    background-color: $background-color;
+  }
+}
+
 .quote {
   color: orangered;
   text-align: center;

--- a/_sass/_layouts/_multicolumn.scss
+++ b/_sass/_layouts/_multicolumn.scss
@@ -1,5 +1,0 @@
-.two-cols {
-    -webkit-column-count: 2; /* Chrome, Safari, Opera */
-    -moz-column-count: 2; /* Firefox */
-    column-count: 2;
-}

--- a/_sass/_layouts/_postlists.scss
+++ b/_sass/_layouts/_postlists.scss
@@ -18,3 +18,7 @@
   font-size: 15px;
   color: #818181;
 }
+
+.pagination {
+
+}

--- a/blog/index.html
+++ b/blog/index.html
@@ -5,7 +5,7 @@ title: Code Club Blog
 
 
 <ul class="posts">
-{% for post in site.posts %}
+{% for post in paginator.posts %}
     {% include post_link.html %}
 {% endfor %}
 </ul>

--- a/css/main.scss
+++ b/css/main.scss
@@ -43,11 +43,17 @@ $mobile: 600px;
   }
 }
 
+@mixin column-count($n) {
+    -webkit-column-count: $n;
+       -moz-column-count: $n;
+            column-count: $n;
+}
+
+
 @import "base",
 
         "_layouts/base",
         "_layouts/footer",
-        "_layouts/multicolumn",
         "_layouts/postlists",
         "_layouts/devices",
 

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@ Do you think it sounds like a great idea, but are looking for an excuse to turn 
 </p>
 
 <ul class="posts">
-  {% for post in site.posts limit:7 %}
+  {% for post in site.posts limit:5 %}
       {% include post_link.html %}
   {% endfor %}
 </ul>


### PR DESCRIPTION
We now have quite a few blog posts - and it's only going to get more in
the future, so we can now split the long lists of posts into many
shorter pages using jekyll's built in pagination features.

- This adds "Next" and "Previous" buttons to the bottom of each page in
  the blog (not the category pages)
- The html for the buttons is defined in `_includes/pagination_nav.html`

Here are a few screenshots
![2015-12-11-122552_1280x800_scrot](https://cloud.githubusercontent.com/assets/2675694/11743813/724e43b8-a002-11e5-8944-0947e4c935c3.png)
![2015-12-11-122604_1280x800_scrot](https://cloud.githubusercontent.com/assets/2675694/11743814/7256da64-a002-11e5-9151-21452d2645da.png)

