### PR TITLE
Proposal: Rename website category to news

### DIFF
--- a/_posts/2014-12-14-A-first-blog-post.md
+++ b/_posts/2014-12-14-A-first-blog-post.md
@@ -1,7 +1,7 @@
 ---
 layout     : post
 title      : "A first blog post"
-categories : website
+categories : news
 tags       : blog
 author     : Vince
 comments   : true

--- a/_posts/2015-01-15-New-computers-for-code-club.md
+++ b/_posts/2015-01-15-New-computers-for-code-club.md
@@ -1,7 +1,7 @@
 ---
 layout     : post
 title      : "New Computers for Code Club"
-categories : website
+categories : news
 tags       : blog
 author     : Jason
 comments   : true

--- a/_posts/2015-02-06-WHERE-IS-EVERYONE.md
+++ b/_posts/2015-02-06-WHERE-IS-EVERYONE.md
@@ -1,13 +1,13 @@
 ---
 layout     : post
 title      : "WHERE IS EVERYONE"
-categories : website
+categories : news
 tags       : blog
 author     : Adam
 comments   : true
 ---
 
-With Vince and Jason still at Python Nambia, it fell to me, Alex and Tim to run Code Club in their stead.  
+With Vince and Jason still at Python Nambia, it fell to me, Alex and Tim to run Code Club in their stead.
 However, due to prior comitments Alex could not make it to code club.
 
 ![I can't see anyone...](/res/blog_pics/WHERE-IS-EVERYONE-pic1.jpg)

--- a/_posts/2015-02-27-special-guest-to-code-club.md
+++ b/_posts/2015-02-27-special-guest-to-code-club.md
@@ -1,7 +1,7 @@
 ---
 layout     : post
 title      : "A special guest for code club"
-categories : website
+categories : news
 tags       : dog
 author     : Vince
 comments   : true

--- a/_posts/2015-09-28-Just-in-time-for-the-new-term-PyDiff.md
+++ b/_posts/2015-09-28-Just-in-time-for-the-new-term-PyDiff.md
@@ -1,7 +1,7 @@
 ---
 layout     : post
 title      : "Just in time for the new Term: PyDiff!"
-categories : website
+categories : news
 tags       : blog
 author     : Vince
 comments   : true

--- a/_posts/2015-10-13-the-first-editor-off.md
+++ b/_posts/2015-10-13-the-first-editor-off.md
@@ -1,7 +1,7 @@
 ---
 layout     : post
 title      : "The first editor off"
-categories : website
+categories : news
 tags       : blog vim atom emacs
 author     : Vince, Alex, Sam, Adam
 comments   : true

--- a/_posts/2015-10-29-How-I-made-a-DOS-at-school.md
+++ b/_posts/2015-10-29-How-I-made-a-DOS-at-school.md
@@ -1,7 +1,7 @@
 ---
 layout     : post
 title      : "How I made a DOS Attack at school"
-categories : website
+categories : news
 tags       : blog
 author     : Ambrose
 comments   : true

--- a/blog/news.html
+++ b/blog/news.html
@@ -1,4 +1,4 @@
 ---
 layout: catpage
-category: website
+category: news
 ---


### PR DESCRIPTION
This might make more sense since most of these posts are updates about
general things at code club, new computers, pydiff, dog visits etc.

Also this would reduce confusion between the website category and the
website tag (which the latter is used to extract relevant articles from
the blog to be listed on the code club website project page)