### PR TITLE
Changing date of command line workshop

### DIFF
--- a/_workshops/2015-2016/the-command-line.md
+++ b/_workshops/2015-2016/the-command-line.md
@@ -3,7 +3,7 @@ layout            : post
 title             : "The Command Line"
 leader            : Alex
 comments          : false
-date              : 2016-02-28
+date              : 2016-02-04
 software-pre-reqs : "SMC account"
 ---
 


### PR DESCRIPTION
Pushing the date back a week to the 4th of Feb so that the first years have
chance to find out about it.