### PR TITLE
Calculating version numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cardiff School of Mathematics Code Club
 [![Build Status](https://travis-ci.org/CardiffMathematicsCodeClub/CardiffMathematicsCodeClub.github.io.svg?branch=master)](https://travis-ci.org/CardiffMathematicsCodeClub/CardiffMathematicsCodeClub.github.io)
-  
+
 A repository for the Cardiff School of Mathematics Code Club: an extra curricular club open to all.
 
 The website for code club is located here - http://cardiffmathematicscodeclub.github.io/
@@ -86,7 +86,7 @@ In fact 'Test Driven Development' is the correct way to write any code:
 3. Write feature that stops test from failing
 
 > Obey the Testing Goat! Do Nothing Until You Have a Test
- 
+
 ![](http://orm-chimera-prod.s3.amazonaws.com/1234000000754/images/twdp_0101.png)
 
 A great explanation of this process is given in [this book](http://chimera.labs.oreilly.com/books/1234000000754/ch01.html) (free to read online and where the goat image is taken from).

--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 #Site settings
 title: Cardiff Math Code Club
 url: "http://CardiffMathematicsCodeClub.github.io"
-version: 3.5.0
+version: 3.5.240
 
 markdown: kramdown
 highlighter: pygments

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Get the latest tags
+git fetch upstream --tags
+
+# Get the latest version in the form x.y
+ver=$(git tag | tail -n 1 | sed 's/v//')
+
+# Get the x part of the version
+major_ver=$(echo $ver | sed 's/\.[0-9]*//')
+
+# Get the y part of the version
+minor_ver=$(echo $ver | sed 's/[0-9]*\.//')
+
+# Calculate the number of commits since the last release for the patch version (z)
+patch_ver=$[ $(git log $(git tag | tail -n 1)..HEAD --pretty=oneline | wc -l) + 1]
+
+# Put it all together
+version="${major_ver}.${minor_ver}.${patch_ver}"
+
+# Finally find and replace in the _config.yml file
+sed -i -- "s/\(version: \)[0-9]*\.[0-9]*\.[0-9]*/\1${version}/" _config.yml
+
+# One last thing, add the changes to the commit
+git add _config.yml
+


### PR DESCRIPTION
So the recent theme changer PR also added a version number to the footer
on the website, currently sat at 3.5.0. This PR now adds a `pre-commit`
script which runs before each commit you make (see below).

The script:

1. Fetches all tags from the upstream repository
2. Looks at the latest tag and extracts the major and minor versions
from it
3. It then looks at the number of commits since that release and adds
that as the patch version
4. It finally does a serach and replace in `_config.yml` to update the
version number.

*IMPORTANT:* For this to work you need to do the following:

- Symlink the script into the actual git hooks directory, by running the
  following from the `hooks` directory
  ```
  $ ln -s pre-commit ../.git/hooks
  ```
- Have the `upstream` remote set up to this repository
- Ensure *all* tags take the form `vX.Y` where X and Y are natural
  numbers