### PR TITLE
Minify CSS

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 #Site settings
 title: Cardiff Math Code Club
 url: "http://CardiffMathematicsCodeClub.github.io"
-version: 3.5.322
+version: 3.5.290
 
 markdown: kramdown
 kramdown:
@@ -14,6 +14,9 @@ paginate_path: "/blog/page:num"
 encoding: utf-8
 description: Cardiff University School of Mathematics Code Club website
 keywords: cardiff,university,uni,maths,math,mathematics,code,club,website,python,java,pascal,vb,elbow,atom,vim,sublime
+
+sass:
+    style: compressed
 
 gems:
     - jekyll-gist


### PR DESCRIPTION
This enables an option in our `_config.yml` which compresses (or minifies if we want to be posh) the css generated by sass.

This means that the css that sits on the live website wouldn't have any whitespace and therefore be a much smaller file for people to download when they visit.

This should also mean that changing themes will work quicker as well 