### PR TITLE
Minor template tweaks

### DIFF
--- a/_includes/catmenu.html
+++ b/_includes/catmenu.html
@@ -8,7 +8,7 @@
      <ul>
      {% assign catlist = site.categories | sort %}
      {% for cat in catlist %}
-         <li><a href="/blog/{{cat | first}}.html">{{cat | first}}</a> ({{cat[1] | size}})</li>
+         <li><a href="/blog/{{cat | first}}.html">{{cat | first | capitalize>}}</a> ({{cat[1] | size}})</li>
      {% endfor %}
      </ul>
 </div>

--- a/_includes/post_link.html
+++ b/_includes/post_link.html
@@ -3,7 +3,8 @@
           <a class="post-link" href="{{post.url}}">{{ post.title }}</a>
         </h4>
         <span class="post-date">
-	  <p>{{ post.date | date: "%b %-d, %y" }}, Written by {{post.author}}</p>
+	          <p> Written by {{post.author}}.
+                Published {{ post.date | date: "%b %-d, %Y" }}{% if post.categories %}, in <a href="/blog/{{post.categories[0]}}">{{post.categories[0] | capitalize}}</a>{% endif %}</p>
 	</span>
         {{ post.excerpt }}
       </li>

--- a/_includes/post_link.html
+++ b/_includes/post_link.html
@@ -4,7 +4,7 @@
         </h4>
         <span class="post-date">
 	          <p> Written by {{post.author}}.
-                Published {{ post.date | date: "%b %-d, %Y" }}{% if post.categories %}, in <a href="/blog/{{post.categories[0]}}">{{post.categories[0] | capitalize}}</a>{% endif %}</p>
+                Published {{ post.date | date: "%b %-d, %Y" }}{% if post.categories.size > 0 %}, in <a href="/blog/{{post.categories[0]}}.html">{{post.categories[0] | capitalize}}</a>{% endif %}</p>
 	</span>
         {{ post.excerpt }}
       </li>

--- a/_layouts/catpage.html
+++ b/_layouts/catpage.html
@@ -14,7 +14,7 @@
 	    <div class="main">
 
 	    <header class="post-header">
-		<h1>Category: {{ page.category }}</h1>
+		<h1>Category: {{ page.category | capitalize}}</h1>
 	    </header>
 
 	    <article class="post-content">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -7,7 +7,7 @@ layout: default
   <header class="post-header">
     <h1>{{ page.title }}</h1>
     <p class="meta">{% if page.author %}Written by  {{ page.author }}. {% endif %} 
-        Published {{ page.date | date: "%b %-d, %Y" }}{% if page.categories %}, in <a href="/blog/{{page.categories[0]}}.html">{{page.categories[0] | capitalize}}</a>{% endif %}</p>
+        Published {{ page.date | date: "%b %-d, %Y" }}{% if page.categories.size > 0 %}, in <a href="/blog/{{page.categories[0]}}.html">{{page.categories[0] | capitalize}}</a>{% endif %}</p>
   </header>
 
   <article class="post-content">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -6,7 +6,8 @@ layout: default
 
   <header class="post-header">
     <h1>{{ page.title }}</h1>
-    <p class="meta">{{ page.date | date: "%b %-d, %Y" }}{% if page.author %} • {{ page.author }}{% endif %}{% if page.meta %} • {{ page.meta }}{% endif %}</p>
+    <p class="meta">{% if page.author %}Written by  {{ page.author }}. {% endif %} 
+        Published {{ page.date | date: "%b %-d, %Y" }}{% if page.categories %}, in <a href="/blog/{{page.categories[0]}}.html">{{page.categories[0] | capitalize}}</a>{% endif %}</p>
   </header>
 
   <article class="post-content">


### PR DESCRIPTION
- Both on the category menu and the category page titles the category name
  is now capitalised

- Tweaked the info line below post titles so that it includes a link to
  the category that the post has been posted in.

![2016-02-18-210656_1920x1080_scrot](https://cloud.githubusercontent.com/assets/2675694/13160415/377ab06e-d68f-11e5-96c9-91698245a298.png)
![2016-02-18-223205_1920x1080_scrot](https://cloud.githubusercontent.com/assets/2675694/13160483/8dc3b18c-d68f-11e5-8df4-e5f9b1b3fa3a.png)
