### PR TITLE
Enabling profiling of builds

### DIFF
--- a/script/cibuild
+++ b/script/cibuild
@@ -4,5 +4,5 @@
 set -e
 
 ./script/link-checker.sh
-bundle exec jekyll build
+bundle exec jekyll build --profile
 #bundle exec htmlproof --url-ignore "http://cardiffmathematicscodeclub.github.io/*" ./_site


### PR DESCRIPTION
Travis will now give a breakdown on how long it takes to build each part
of the website, this may allow us to look at reducing bottlenecks in the
building of the site