### PR TITLE
Add twitter cards for blog posts

### DIFF
--- a/_includes/twitter_card_post.html
+++ b/_includes/twitter_card_post.html
@@ -1,0 +1,4 @@
+<meta name="twitter:card" content="summary"/>
+<meta name="twitter:site" content="@cardiffmathcode"/>
+<meta name="twitter:title" content="{{page.title}}"/>
+<meta name="twitter:description" content="{{page.excerpt | strip_html}}"/>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,6 +2,10 @@
 <html>
 <head>
   {% include common_head.html %}
+
+  {% if page.layout == 'post' %}
+    {% include twitter_card_post.html %}
+  {% endif %}
 </head>
     <body>
 


### PR DESCRIPTION
- This is an experiment having just come accross
  [twitter cards.](https://dev.twitter.com/cards/types/summary)
- By adding a few `<meta>` tags in our html, whenever people tweet a
  link to the website, twitter scrapes the linked page looking for these
  tags and if they are found displays a nice looking card in the body of
  a tweet.
- This PR is an attempt to add the necessary meta tags to implement
  this for blog posts.

- I have also created a twitter account for code club (no idea if people
  want this so currently it's not really visible - I want to hear your
  thoughts on this.)
- If people decide they want a twitter account for code club then these
  cards can be linked to the account and we in theory can get some
  metrics on how people interact with tweets containing links to the
  site (again no idea if people want this - let me know your thoughts).

- To test this, it's basically a case of adding these tags and then
  tweeting a link and checking to see if twitter can parse this and add
  the card appropriately.