### PR TITLE
Choosing a default logo for the twitter feed

### DIFF
--- a/_sass/_layouts/_base.scss
+++ b/_sass/_layouts/_base.scss
@@ -71,6 +71,10 @@ select {
         width: 64px;
         height: 64px;
     }
+
+    .white {
+        display: none;
+    }
 }
 
 .tweets {

--- a/_sass/_themes/_cardiffred/_base.scss
+++ b/_sass/_themes/_cardiffred/_base.scss
@@ -65,6 +65,10 @@ header.site-header {
     @include border-top-right-radius(5px);
     @include border-top-left-radius(5px);
 
+    .white {
+        display: block;
+    }
+
     .blue {
         display: none;
     }


### PR DESCRIPTION
So having both logos be displayed at once is dumb and looks stupid so
this now sets a default in the `_sass/_layouts/_base.scss` file as with
the twitter feed theme.

The default is the **blue** logo as it should be visible on most themes
we currently have. If you want the blue logo then you don't have to
change anything.

If you want to change from the default to the white logo then you need
to add the following CSS to your theme:
```
.sidetab > .blue {
    display: none;
}

.sidetab > .white {
    display: block;
}
```