### PR TITLE
Version bump and script

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 #Site settings
 title: Cardiff Math Code Club
 url: "http://CardiffMathematicsCodeClub.github.io"
-version: 4.0.157
+version: 4.0.208
 
 exclude:
     - templates

--- a/script/bump-version.sh
+++ b/script/bump-version.sh
@@ -18,6 +18,9 @@ patch_ver=$[ $(git log $(git tag | tail -n 1)..HEAD --pretty=oneline | wc -l) + 
 # Put it all together
 version="${major_ver}.${minor_ver}.${patch_ver}"
 
+# Tell the user
+echo "Bumped to version v$version"
+
 # Finally find and replace in the _config.yml file
 sed -i -- "s/\(version: \)[0-9]*\.[0-9]*\.[0-9]*/\1${version}/" _config.yml
 


### PR DESCRIPTION
For a few months now there's been a script `hooks/pre-commit` which
calculates the version of the code club website according to the
scheme `<major>.<minor>.<patch>`. Where the major and minor versions are
set by the latest tag and the patch number is simply the number of
commits that have been made since the last version tag.

The original idea was to have this run everytime people make a commit on
the site, however after a few trial runs we found that this caused
neverending merge conflicts since everyone was editing the same line in
the same file.

But there's nothing wrong with someone running the script from time to
time to bump the version number, so this commit simply moves and renames
this script so that it is more obvious to everyone what it is.

The script is now called `script/bump-version.sh`

To run the script simply run the following from the same folder as the
`README`:

```
$ ./script/bump-version.sh
```

This will then calculate the version number, add it to the `_config.yml`
file and add it to the staging area. All that's left for you to do is
run `git commit` and submit a PR with the new version number.