### PR TITLE
Fixing twitter

### DIFF
--- a/_includes/twitter_feed.html
+++ b/_includes/twitter_feed.html
@@ -4,18 +4,18 @@
 </div>
 
 <div class="tweets">
-    <div class="feed light">
+    <div class="feed">
         <span class="dark">
-            <a class="twitter-timeline"  href="https://twitter.com/cardiffmathcode" data-widget-id="730463167378276353">Tweets by @cardiffmathcode</a>
-            <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
+            <a class="twitter-timeline"  href="https://twitter.com/cardiffmathcode" data-widget-id="731165055417516032">Tweets by @cardiffmathcode</a>
+            <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>       
         </span>
         <span class="light">
-            <a class="twitter-timeline"  href="https://twitter.com/cardiffmathcode" data-widget-id="729091854722056194">Tweets by @cardiffmathcode</a>
+            <a class="twitter-timeline"  href="https://twitter.com/cardiffmathcode" data-widget-id="731164663996661764">Tweets by @cardiffmathcode</a>
             <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
         </span>
     </div>
 </div>
 
-
+          
           
           

--- a/_sass/_themes/_cardiffred/_base.scss
+++ b/_sass/_themes/_cardiffred/_base.scss
@@ -84,7 +84,7 @@ header.site-header {
     }
 
     .feed > .light {
-        display: block;
+        display: none;
     }
 }
 


### PR DESCRIPTION
This tweaks the twitter widgets so that they are actually all on screen
correctly rather than stopping halfway down.

This also fixes the cardiff red theme which was actually displaying
both timelines at once.

**IMPORTANT:** The widgets that are on the live site no longer exist so
the feed is currently broken on the live site (I deleted them before
realising it affected the site)