### PR TITLE
Testing z-index for twitter feed

### DIFF
--- a/_sass/_layouts/_base.scss
+++ b/_sass/_layouts/_base.scss
@@ -62,6 +62,7 @@ select {
 /* Twitter Feed */
 .sidetab {
     position: fixed;
+    z-index: 999;
     padding-right: 10px;
     bottom: 0;
     right: 10px;
@@ -80,6 +81,7 @@ select {
 .tweets {
     display: none;
     position: fixed;
+    z-index: 999;
     bottom: 0;
     right: 10px;
     max-height: 400px;


### PR DESCRIPTION
On mobile I've found the browser to get confused when scrolling on 
the twitter feed. Often it will also scroll the page behind the feed and 
produce visual glitches. This is a test to see if elevating the element
will fix it