### PR TITLE
Add searching the documentation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,6 +27,8 @@ gems:
 collections:
   workshops:
     output: true
+  docs:
+    output: true
   languages:
     output: true
   projects:

--- a/_docs/index.md
+++ b/_docs/index.md
@@ -1,20 +1,15 @@
 ---
 layout: page
 title: Documentation
+script: 
+  - https://cdnjs.cloudflare.com/ajax/libs/lunr.js/0.7.1/lunr.min.js
+  - /js/docsearch.js
 ---
-
 Welcome to the Code Club Website's Documentation! Here you will find out how
 we build the website, everything from adding blog posts and language pages to
 how the theme changer works!
 
-_Note:_ This part of the website is still very young, so we haven't quite
-figured out how best to structure the documentation yet. Don't worry we are
-working to fix it and should have someting better in the coming months.
+Just use the search box below to get started
 
-<ul>
-  {% for doc in site.docs %}
-    {% unless {{doc.title}} == "Documentation" %}
-      <li><a href="{{doc.url}}">{{doc.title}}</a></li>
-    {% endunless %}
-  {% endfor %}
-</ul>
+<input id="search" placeholder="Search the docs..." type="search">
+<div id="results"></div>

--- a/_docs/index.md
+++ b/_docs/index.md
@@ -1,0 +1,20 @@
+---
+layout: page
+title: Documentation
+---
+
+Welcome to the Code Club Website's Documentation! Here you will find out how
+we build the website, everything from adding blog posts and language pages to
+how the theme changer works!
+
+_Note:_ This part of the website is still very young, so we haven't quite
+figured out how best to structure the documentation yet. Don't worry we are
+working to fix it and should have someting better in the coming months.
+
+<ul>
+  {% for doc in site.docs %}
+    {% unless {{doc.title}} == "Documentation" %}
+      <li><a href="{{doc.url}}">{{doc.title}}</a></li>
+    {% endunless %}
+  {% endfor %}
+</ul>

--- a/_docs/project-structure.md
+++ b/_docs/project-structure.md
@@ -1,0 +1,178 @@
+---
+layout: page
+title: Project Structure 
+---
+
+This page simply outlines how this project is structured so you can use it as a
+road map to help you find what you are looking for and where you can find out
+more information.
+
+## Jekyll Collections
+
+The main bulk of the content of the website is made up of various
+[Jekyll Collections][collections] they allow us to focusing on writing our
+content in [Markdown][markdown] without having to worry about HTML, CSS or
+anything else that usually goes with making a website.
+
+### Folders
+
+- `_docs` This contains all the documentation for the website (which you are
+  currently reading).
+  
+- `_drafts` In this folder you can put draft blog posts that you are working on
+  but don't want to have published yet, they will show up on your machine but not
+  the live version of the site.
+
+- `_languages` This contains all the reference pages for programming languages
+  such as C, Python, Haskell etc. 
+  
+- `_posts` In this folder we put all of our blog posts which are published, on
+  the live version of the site.
+  
+- `_projects` Here we specify all the projects that Code Club has worked on,
+  both past and present. 
+  
+- `_tools` This is where we put the reference pages for tools, libraries and
+  other utilies which makes working with languages easier. 
+  
+- `_workshops` Here is where we schedule any workshops that are upcoming.
+  
+## Other Content
+
+The rest of the content for the website can be found in a few other locations.
+
+### Folders
+
+- `blog` This is a folder with a few HTML files, if you look at them there isn't
+  much in there. They are there just to get Jekyll to generate a page for each
+  of the categories in our blog.
+
+- `res` This folder contains all the images that we have on the site, as well as
+  the source files for the logo. (`.xcf` - Like `.psd` files for Photoshop but
+  for the open source alternative [GIMP][gimp])
+
+### Files
+- `404.html` This is the page that gets displayed if users happen to try and
+  load a page which doesn't exist.
+
+- `archive.md` This is the Archive page, with links to past workshops, blog
+  posts and session quotes.
+
+- `coc.md` This is the code of conduct for while at code club
+
+- `getinvolved.md` This is the Getting involved page, with links to ongoing
+  projects, programming challenges and contributors to the site.
+
+- `index.html` This is the home page of the website
+
+- `projects.md` This is the list of all projects, including ones which are no
+  longer active.
+
+- `reference.md` This is the main reference page with links to all of the
+  language and tool pages.
+
+- `sessions.html` Here is the list of all the past session quotes.
+
+- `workshops.md` This is the main workshops page, it lists all the workshops,
+  both past and upcoming.
+  
+- `favicon.png` This is a small version of the code club logo, it is used for
+  example by browsers when they display our logo on the current tab.
+ 
+## Website Internals
+
+This section contains all the folders and files which go into taking the content
+above and turning it into a website with the help of [Jekyll][jekyll]
+
+### Folders
+
+- `_data` This folder contains a number of YAML (`.yml`) files which contains
+  information that we use with Jekyll to build to website. We have the list of
+  contributors, session quotes as well as the website's menu and themes defined
+  here.
+  
+- `_includes` This folder contains various snippets of HTML which can be
+  imported into templates and webpages. Here things like the twiiter feed and the
+  website footer are defined here.
+  
+- `_layouts` Here we define the HTML templates that Jekyll uses to compile the
+  website with. This is a good place to define things that are needed for large
+  groups of pages on the website, e.g. we have a `blog` template which
+  automatically adds the category menu to all pages on the blog to let users
+  filter which sort of posts show up easily. 
+  
+- `_sass` This folder contains the bulk of the CSS for our site, written using a
+  preprocessor SASS (`.scss` files), here we have all the themes and a default
+  layout for the site that theme creators can use so they can concentrate on
+  making the site look good. Think of this folder as the `_includes` folder we
+  mentioned above, but for CSS.
+  
+- `_site` Jekyll takes our project and compiles it into a website, after
+  finishing this process it stores the result here - can be useful when
+  debugging issues to look at the generated HTML.
+  
+- `css` Here the main theme files are stored, they are also written in SASS like
+  those in the `_sass` directory. The main files mostly contain variables and
+  import statements while the bulk of the themes are defined in the `_sass`
+  folder.
+  
+- `js` This folder contains all the Javascript that we have on the site it's
+  here where we implement things like the theme changer and the showing and
+  hiding of the twitter feed. Anything interactive on the site tends to be done
+  using Javascript
+  
+### Files
+
+- `_config.yml` Here we specify all of our options to Jekyll such as what
+  collections we use, any extra gems we want Jekyll to use etc.
+
+## Other 
+
+This final section contains items which aren't directly used to make the site,
+but often make life much easier for us by being there.
+
+### Folders
+
+- `script` This folder contains scripts which do things like calculating the new
+  version number for the site, or defining particular tests to run.
+
+### Files
+
+- `.gitignore` To keep track of changes and help streamline the process of
+  having multiple people work on the site at the same time we use a tool called
+  [Git][git]. This file lists certain filetypes and folders which we don't want
+  git to keep track of - like the `_site` folder created by Jekyll.
+- `README.md` This is the project's README file. It is the first thing people
+  see when they visit the project on [github][github] it contains instructions
+  on how people can get started with contributing to the site along with some
+  introductory documentation.
+- `Gemfile` This is a list of Ruby dependencies that are needed to be able to
+  run the site on your machine, it also helps us to keep the versions of the
+  dependencies up to date with those on [github pages][gh-pages] where our site
+  is hosted.
+- `Rakefile` This defines a number of commands that you can run which help
+  automate particular jobs when working on the site, everything from running the
+  tests to publishing draft blog posts and adding new themes.
+- `.travis.yml` We have a number of tests that we run on the site to make sure
+  everything is working ok (such as making sure all our links point somewhere).
+  We use a service called [Travis][travis] to make sure that whenever we make
+  changes to the website our tests are automatically run and we can tell quickly
+  if something has broken. This file contains instructions for Travis on how to
+  run our tests.
+- `Dockerfile` [Docker][docker] allows you to run lightweight "containers" on
+  your machine (containers are like virtualbox but for single applications
+  rather than entire operating systems). We give people the option of using
+  docker to build and run the site, this file contains the instructions required
+  for docker to build the image that you can build the site with.
+- `.dockerignore` This tells which files docker can safely ignore when building
+  its image for the site.
+
+[collections]: https://jekyllrb.com/docs/collections/
+[docker]:      https://www.docker.com/
+[gh-pages]:    https://pages.github.com/versions/
+[gimp]:        https://www.gimp.org/
+[git]:         https://git-scm.com/
+[github]:      https://github.com/CardiffMathematicsCodeClub/CardiffMathematicsCodeClub.github.io
+[jekyll]:      https://jekyllrb.com/
+[markdown]:    https://daringfireball.net/projects/markdown/
+[travis]:      https://travis-ci.org/

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,6 +6,10 @@
   {% if page.layout == 'post' %}
     {% include twitter_card_post.html %}
   {% endif %}
+
+  {% for script in page.script %}
+    <script src="{{script}}" type="text/javascript"></script>    
+  {% endfor %}
 </head>
     <body>
 

--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -13,29 +13,46 @@ layout: default
       <h3>About</h3>
 
       <ul>
-	<li>Project Home: <a href="{{page.github}}">{{page.gitshow}}</a></li>
-	{% if page.link %}
-	<li>Documentation: <a href="{{page.link}}">{{page.link}}</a></li>
-	{% endif %}
+        <li><a href="{{page.github}}">Project Home</a></li>
+        {% if page.link %}
+            <li><a href="{{page.link}}">Documentation</a></li>
+        {% endif %}
       </ul>
 
       {{content}}
 
+
+      <h3>News</h3>
+
+      <p>
+        Here you can find the latest updates and announcements about the project.
+      </p>
+      
+      {% assign news = site.categories["news"]  %}
+
+      <ul>
+        {% for post in news %}
+          {% if post.tags contains {{page.tag}} %}
+            <li>{{page.date | date: "%d-%m-%Y"}}: <a href="{{post.url}}">{{post.title}}</a></li>
+          {% endif %}
+        {% endfor %}
+      </ul>
+
       <h3>Getting Started</h3>
 
       <p>
-	Want to get involved? Great! Not sure where to start? Don't worry!
-	We have you covered, below is a list of tutorials where you can find out
-	how to get involved. We can't wait for you first pull request!
+        Want to get involved? Great! Not sure where to start? Don't worry!
+        We have you covered, below is a list of tutorials where you can find out
+        how to get involved. We can't wait for you first pull request!
       </p>
 
       {% assign tutorials = site.categories["tutorial"] | sort %}
 
       <ul>
-	{% for post in tutorials %}
-	  {% if post.tags contains {{project.tag}} and post.tags contains "getstarted"%}
-	     <li><a href="{{post.url}}">{{post.title}}</a></li>
-	  {% endif %}
+        {% for post in tutorials %}
+            {% if post.tags contains {{page.tag}} and post.tags contains "getstarted"%}
+                <li><a href="{{post.url}}">{{post.title}}</a></li>
+            {% endif %}
         {% endfor %}
       </ul>
 

--- a/_posts/2014-12-14-A-first-blog-post.md
+++ b/_posts/2014-12-14-A-first-blog-post.md
@@ -2,7 +2,7 @@
 layout     : post
 title      : "A first blog post"
 categories : news
-tags       : blog
+tags       : website
 author     : Vince
 comments   : true
 ---

--- a/_posts/2015-01-15-New-computers-for-code-club.md
+++ b/_posts/2015-01-15-New-computers-for-code-club.md
@@ -2,7 +2,7 @@
 layout     : post
 title      : "New Computers for Code Club"
 categories : news
-tags       : blog
+tags       : website
 author     : Jason
 comments   : true
 ---

--- a/_posts/2015-12-15-Introducing-micro-workshops.md
+++ b/_posts/2015-12-15-Introducing-micro-workshops.md
@@ -2,6 +2,7 @@
 layout     : post
 title      : "Introducing micro workshops"
 categories : news
+tags       : website
 author     : Vince
 comments   : true
 ---

--- a/_posts/2016-02-10-introducing-themes.md
+++ b/_posts/2016-02-10-introducing-themes.md
@@ -1,7 +1,8 @@
 ---
 layout: post
 title: Introducing Themes and More!
-categories: news
+category: news
+tags: website
 author: Alex
 comments: true
 ---

--- a/_projects/website.md
+++ b/_projects/website.md
@@ -2,7 +2,8 @@
 layout: project
 name: 'Code Club Website'
 github: https://github.com/CardiffMathematicsCodeClub/CardiffMathematicsCodeClub.github.io
-gitshow: CardiffMathematicsCodeClub/ CardiffMathematicsCodeClub.github.io
 description: 'The very website you are currently looking at.'
 active: true
+link: /docs
+tag: website
 ---

--- a/js/docsearch.js
+++ b/js/docsearch.js
@@ -1,0 +1,74 @@
+---
+# Thanks to katydecorah.com/code/lunr-and-jekyll/ for details on how to se this up
+---
+
+// Tell lunr about which fields we want in the index
+var index = lunr(function(){
+    this.field("title");
+    this.field("content");
+    this.ref("id");
+});
+
+// Next we need to build the index so we get jekyll to loop over the document
+// collection and add each one in turn to the index
+{% assign count = 0 %}
+{% for doc in site.docs %}
+
+    index.add({
+        title: {{doc.title | jsonify}},
+        content: {{doc.content | strip_html | jsonify}},
+        id: {{count}}
+    });
+
+    {% assign count = count | plus: 1 %}
+
+{% endfor %}
+
+// Lunr only returns the index number of the result, so we need to keep track of
+// index ourselves
+var store = [{% for doc in site.docs %} {
+    'title': {{doc.title | jsonify}},
+    'link': {{doc.url | jsonify}},
+    'excerpt': {{doc.content | strip_html | truncatewords: 20 | jsonify}}
+    }{% unless forloop.last %},{% endunless %}{% endfor %}
+];
+
+// Finally we need to make the search box useful
+$(document).ready(function(){
+
+    $("input#search").on("keyup", function(){
+        // "Pick up" the results div
+        var results = $("#results");
+
+        // Get the query string and search
+        var query = $(this).val();
+        var result = index.search(query);
+
+        // Clear the previous results
+        results.empty();
+
+        // // Start a list
+        results.append("<ul>");
+
+        // // Loop through the results and put them in the result div
+        for (item in result) {
+            var ref = result[item].ref;
+
+            var resitem = "<a href='" + store[ref].link + "'>"
+                   + "<h4>" +  store[ref].title + "</h4>" + "</a>"
+                    + "<p>" + store[ref].excerpt + "</p>";
+
+            results.append(resitem);
+        }
+
+        // Finish the list
+        results.append("</ul>");
+
+        console.log("Searching...");
+    });
+    //Each time the user types a character
+    // $("inupt#search").on("keyup", function() {
+
+
+    // });
+});


### PR DESCRIPTION
This depends on #207 

Using [lunr.js](http://lunrjs.com) and following [this](http://katydecorah.com/code/lunr-and-jekyll/) excellent guide,
we can now search the documentation! It isn't great just yet since
there is only two items in the documentation for now, but as
more and more it added it should become quite useful.

Although we still need to create some sort of structure as well since it
would help first time users find out what is actually documented.

In order to implement this I ended up modifying the
`_layouts/default.html` template, this adds support for a new
frontmatter term `script`

The `script` item can be used to add extra javascript scripts to the
head of an HTML document without the need for defining an entirely new
layout just for that.

Let me know what you think, do we also want something like this for our reference section and blog posts?

![2016-05-19-004347_1920x1080_scrot](https://cloud.githubusercontent.com/assets/2675694/15378381/d209614a-1d5a-11e6-85a1-8a41390665e8.png)
![2016-05-19-004356_1920x1080_scrot](https://cloud.githubusercontent.com/assets/2675694/15378382/d66e1f28-1d5a-11e6-9382-614a05ac232e.png)
![2016-05-19-004404_1920x1080_scrot](https://cloud.githubusercontent.com/assets/2675694/15378383/da740bfa-1d5a-11e6-84e9-9fe31353b853.png)


