### PR TITLE
Fix typo on project template

### DIFF
--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -33,7 +33,7 @@ layout: default
       <ul>
         {% for post in news %}
           {% if post.tags contains {{page.tag}} %}
-            <li>{{page.date | date: "%d-%m-%Y"}}: <a href="{{post.url}}">{{post.title}}</a></li>
+            <li>{{post.date | date: "%d-%m-%Y"}}: <a href="{{post.url}}">{{post.title}}</a></li>
           {% endif %}
         {% endfor %}
       </ul>


### PR DESCRIPTION
This fixes a typo on the project page template which caused the date for
each news item to be the date that the page was generared, rather than
the date that the actual news item was written.