### PR TITLE
Adding Haskell page!

### DIFF
--- a/_languages/C++.md
+++ b/_languages/C++.md
@@ -1,7 +1,6 @@
 ---
 layout: language
 language: c++
-title: C++
 ---
 
 <b><u>Overview </u></b>

--- a/_languages/C.md
+++ b/_languages/C.md
@@ -1,35 +1,35 @@
 ---
 layout: language
 language: c
-title: C
 ---
 
 ### Overview
 
 C is one the oldest languages still in active use today, first created 1972 by
-Dennis Ritchie at [Bell Labs][bell-labs] and has gone through many revisions as
+Dennis Ritchie at [Bell Labs][bell-labs] it has gone through many revisions as
 the years have progressed with the most recent edition [C11][c11] released early
 in 2011.
 
-However due to the way C is developed, where a committee drafts a standard with
-C's rules and features and it's up to the compiler developers to implement them.
-This mean that many of the more recent features are still not available for
-certain compilers/platforms so many people try to adhere to the [C99][c99]
-or even [ANSI][ansi-c] (the original release) standards to increase portability.
+The language is developed by committee who write a standard which compiler
+developers then use as a basis for their implementations. This usually means
+different features are supported to different extents depending on your choice
+of compiler. This sometimes means that developers adhere to the [C99][c99] or
+[ANSI][ansi-c] standards to maximize support across platforms
 
 C has been a hugely influential language and has inspired the design of many of
-newer languages including C++, Java, Go, Python and many, many more. C has and
-still is so popular due to the fact it is extremely portable, chances are a
-compiler exists for almost any processor architecture out there and produces
-extremely fast executables.
+the newer languages including C++, Java, Go, Python and many, many more. C has
+been and still is so popular due to the fact it is extremely portable, chances
+are a compiler exists for almost any processor architecture out there. C is also
+one of the fastest languages in existence and you will often see benchmarks for
+new languages compare themselves with it.
 
 But that speed comes at a cost, anything but the simplest of tasks are left to
 the programmer. This means when programming in C you have to manage your own
 memory, perform bound checks on arrays and more. If you forget to ensure you
-don't actually access memory you have to right to at best you can introduce a
-bug that will crash your program, however a hacker can exploit this and inject
-malicious code into your program and basically hi-jacking you or your clients'
-machine...
+don't accidentally access memory you have no right to you can introduce a bug
+that will crash your program. Or worse still a hacker can exploit this bug and
+inject malicious code into your program and get the computer to do nearly
+anything they want
 
 If you would like more information about the history or evolution of this
 language then you can follow [this][cwiki] link
@@ -37,7 +37,7 @@ language then you can follow [this][cwiki] link
 ### Applications
 
 C is heavily used for working with hardware, so many device drivers and
-operating systems such as Linux are implemented in C. It's performance means
+operating systems such as Linux are implemented in C. Its performance means
 it's a popular choice for real-time systems and applications such as video
 games. Also languages such as Python, Perl and PHP all have their interpreters
 written in C.

--- a/_languages/brainfk.md
+++ b/_languages/brainfk.md
@@ -1,6 +1,5 @@
 ---
 layout: language
-language: bf
-title: Brainf**k
+language: brainf**k
 tags: forfun
 ---

--- a/_languages/clojure.md
+++ b/_languages/clojure.md
@@ -1,5 +1,4 @@
 ---
 layout: language
 language: clojure
-title: Clojure
 ---

--- a/_languages/haskell.md
+++ b/_languages/haskell.md
@@ -1,5 +1,140 @@
 ---
 layout: language
 language: haskell
-title: Haskell
 ---
+
+### Overview 
+
+Haskell is a lazy, purely functional, statically typed programming language
+named after the logician Haskell Curry. Despite the recent popularity surge of
+functional languages Haskell is not a recent development having its first
+release in 1990.
+
+It was influenced by a language called [Miranda][miranda] which saw its first
+release in 1985 and spawned a wide array of other lazy functional languages.
+Haskell grew out of a desire to move away from the proprietary language Miranda
+and consolidate the advances made in language design into a single language.
+
+Following Haskell 1.0, there were number of additional specifications until the
+Haskell98 specification was released and is considered the first "stable"
+release. Published in 2010 Haskell2010, is the most recent Haskell
+specification.
+
+Being a language designed by specification there are many different
+implementations of Haskell, however by far the most popular and feature complete
+is [The Glasgow Haskell Compiler (GHC)][ghc] which is widely considered _the_
+implementation of Haskell.
+
+While Haskell has mostly been used as an academic language especially in the
+early days it is used in industry by companies such as Facebook and there are
+libraries for almost use case from web servers to games.
+
+For more information you can go [here][haskell-wiki]
+
+
+### Applications
+
+Here is a short list of applications that have been written using Haskell:
+
+- [Pandoc][pandoc]: A document conversion tool
+- [Darcs][darcs]: A version control system, like Git but with a different
+  approach to tracking changes
+- [Xmonad][xmonad]: A tiling window manager for Linux
+
+### Some Code
+
+Hello World:
+
+``` haskell
+main :: IO ()
+main = putStrLn "Hello World"
+```
+
+A program that will print the first 100 Fibonacci numbers:
+
+``` haskell
+fibs :: [Int]
+fibs = 0 : 1 : zipWith (+) fibs (tail fibs)
+
+main :: IO ()
+main = print $ take 100 fibs
+```
+
+### Useful Libraries and Tools
+
+__Compilers and Interpreters__
+
+Haskell is a compiled language, it first gets compiled to an intermediate
+language which is then used to generate code for whatever the target platform
+is.
+
+- [GHC][ghc]: As mentioned above considered _the_ implementation of Haskell also
+  comes with an interpreter `ghci` which lets you try out various Haskell
+  expressions in a REPL like environment.
+- [GHCJS][ghcjs]: Built using GHC allows you to compile Haskell code to
+  Javascript.
+- [Frege][frege]: Compiles most Haskell code to the JVM (Java) and allows for
+  easy use of native Java libraries and integration with Java code.
+- [Hugs][hugs]: Used to be one of the main "competitors" to GHC, implementing
+  the Haskell98 standard. However it is no longer under development.
+  
+__Build Tools__
+
+Build tools are there to automate the process of compiling and managing your
+programs letting you focus on more important things like writing code.
+
+- [Cabal][cabal]: Is the build tool which ships with GHC and can also be used to
+  install Haskell programs from source. However it can lead to trouble when used
+  accross multiple projects with a problem commonly referred to as
+  ["Cabal Hell"][cabal-hell]
+- [Stack][stack]: This is a relatively recent development in the Haskell
+   community and builds on top of Cabal in an attempt to solve "Cabal Hell" by
+   working with [Stackage][stackage] which maintains lists of packages and their
+   versions which "play nice" with each other.
+   
+__Libraries__
+
+Libraries are collections of code which are designed to make a particular task
+easier to perform, reducing the number of things you have to build and maintain
+yourself.
+
+- [Hakyll][hakyll]: A library which helps you create a static site generator
+  (like Jekyll) in very few lines of code.
+- [Yesod][yesod]: A web framework for Haskell - like Python's Django
+- [Diagrams][diagrams]: Used to create vector graphics
+- [LambdaHack][lambdahack]: A game engine focused on creating rouge-like dungeon
+  crawlers like NetHack.
+
+You can find a list of many, many more Haskell packages [here][hackage] on
+Hackage
+
+[cabal]:        https://www.haskell.org/cabal/
+[cabal-hell]:   https://en.wikipedia.org/wiki/Cabal_(software)#Criticism
+[darcs]:        http://darcs.net/
+[diagrams]:     http://projects.haskell.org/diagrams/
+[frege]:        https://github.com/Frege/frege
+[ghc]:          https://www.haskell.org/ghc/
+[ghcjs]:        https://github.com/ghcjs/ghcjs
+[hackage]:      https://hackage.haskell.org/packages
+[hakyll]:       https://jaspervdj.be/hakyll/
+[haskell-wiki]: https://en.wikipedia.org/wiki/Haskell_(programming_language)
+[hugs]:         https://www.haskell.org/hugs/
+[lambdahack]:   https://hackage.haskell.org/package/LambdaHack
+[miranda]:      https://en.wikipedia.org/wiki/Miranda_(programming_language)
+[pandoc]:       http://pandoc.org/
+[stack]:        http://www.haskellstack.org/
+[stackage]:     https://www.stackage.org/
+[xmonad]:       http://xmonad.org/
+[yesod]:        http://www.yesodweb.com/
+
+
+
+
+
+
+
+
+
+
+
+ 

--- a/_languages/java.md
+++ b/_languages/java.md
@@ -1,5 +1,4 @@
 ---
 layout: language
 language: java
-title: Java
 ---

--- a/_languages/python.md
+++ b/_languages/python.md
@@ -1,5 +1,4 @@
 ---
 layout: language
 language: python
-title: Python
 ---

--- a/_layouts/language.html
+++ b/_layouts/language.html
@@ -4,7 +4,7 @@ layout: default
 <div class="post">
 
   <header class="post-header">
-    <h1>{{ page.title }}</h1>
+    <h1>{{ page.language | capitalize }}</h1>
   </header>
 
   <article class="post-content">

--- a/reference.md
+++ b/reference.md
@@ -29,7 +29,7 @@ However there are many more than that! Below is just a sample of them.
     <ul>
         {% for page in site.languages %}
 	        {% unless page.tags contains "forfun" %}
-                <li><a href="{{ page.url }}">{{ page.title }}</a></li>
+                <li><a href="{{ page.url }}">{{ page.language | capitalize }}</a></li>
 	        {% endunless %}
         {% endfor %}
     </ul>
@@ -50,7 +50,7 @@ a long list of these languages!
     <ul>
         {% for page in site.languages %}
 	        {% if page.tags contains "forfun" %}
-                <li><a href="{{ page.url }}">{{ page.title }}</a></li>
+                <li><a href="{{ page.url }}">{{ page.language | capitalize }}</a></li>
 	        {% endif %}
         {% endfor %}
     </ul>


### PR DESCRIPTION
This should go some way towards closing #25 

- This finally adds the Haskell language page to the website! :metal:
- Reworded parts of the C language page since I can't English
- Tweaked some template code so we no longer have to specify the `title`
  in the language pages. The templates are now smart enough to work out
  the title from the `language` attribute